### PR TITLE
Fix/handle error object already exists s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/segmentio/parquet-go"
 	log "github.com/sirupsen/logrus"
-	"gitlab.com/rivian/rel/delta-go"
-	"gitlab.com/rivian/rel/delta-go/lock/filelock"
-	"gitlab.com/rivian/rel/delta-go/state/filestate"
-	"gitlab.com/rivian/rel/delta-go/storage"
-	"gitlab.com/rivian/rel/delta-go/storage/filestore"
+	"github.com/rivian/delta-go"
+	"github.com/rivian/delta-go/lock/filelock"
+	"github.com/rivian/delta-go/state/filestate"
+	"github.com/rivian/delta-go/storage"
+	"github.com/rivian/delta-go/storage/filestore"
 )
 
 func main() {

--- a/delta.go
+++ b/delta.go
@@ -415,7 +415,7 @@ func (transaction *DeltaTransaction) TryCommitLoop(commit *PreparedCommit) error
 		err := transaction.TryCommit(commit)
 		//Reset local state with the version tried in the commit
 		//The next attempt should use the max of the remote state and local state, enables local incrimination if the remote state is stuck
-		if errors.Is(err, storage.ErrorVersionAlreadyExists) || errors.Is(err, lock.ErrorLockNotObtained) || errors.Is(err, storage.ErrorObjectAlreadyExists) { //|| errors.Is(err, state.ErrorStateIsEmpty) || errors.Is(err, state.ErrorCanNotReadState) || errors.Is(err, state.ErrorCanNotWriteState) {
+		if errors.Is(err, storage.ErrorObjectAlreadyExists) || errors.Is(err, lock.ErrorLockNotObtained) { //|| errors.Is(err, state.ErrorStateIsEmpty) || errors.Is(err, state.ErrorCanNotReadState) || errors.Is(err, state.ErrorCanNotWriteState) {
 			if attemptNumber <= int(transaction.Options.MaxRetryCommitAttempts)+1 {
 				attemptNumber += 1
 				// log.Debugf("Transaction attempt failed with %e. Incrementing attempt number to %d and retrying.", err, attemptNumber)

--- a/delta.go
+++ b/delta.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rivian/delta-go/lock"
+	"github.com/rivian/delta-go/state"
+	"github.com/rivian/delta-go/storage"
 	log "github.com/sirupsen/logrus"
-	"gitlab.com/rivian/rel/delta-go/lock"
-	"gitlab.com/rivian/rel/delta-go/state"
-	"gitlab.com/rivian/rel/delta-go/storage"
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/maps"
 )

--- a/delta.go
+++ b/delta.go
@@ -415,7 +415,7 @@ func (transaction *DeltaTransaction) TryCommitLoop(commit *PreparedCommit) error
 		err := transaction.TryCommit(commit)
 		//Reset local state with the version tried in the commit
 		//The next attempt should use the max of the remote state and local state, enables local incrimination if the remote state is stuck
-		if errors.Is(err, storage.ErrorVersionAlreadyExists) || errors.Is(err, lock.ErrorLockNotObtained) { //|| errors.Is(err, storage.ErrorObjectAlreadyExists) || errors.Is(err, state.ErrorStateIsEmpty) || errors.Is(err, state.ErrorCanNotReadState) || errors.Is(err, state.ErrorCanNotWriteState) {
+		if errors.Is(err, storage.ErrorVersionAlreadyExists) || errors.Is(err, lock.ErrorLockNotObtained) || errors.Is(err, storage.ErrorObjectAlreadyExists) { //|| errors.Is(err, state.ErrorStateIsEmpty) || errors.Is(err, state.ErrorCanNotReadState) || errors.Is(err, state.ErrorCanNotWriteState) {
 			if attemptNumber <= int(transaction.Options.MaxRetryCommitAttempts)+1 {
 				attemptNumber += 1
 				// log.Debugf("Transaction attempt failed with %e. Incrementing attempt number to %d and retrying.", err, attemptNumber)

--- a/delta_test.go
+++ b/delta_test.go
@@ -26,12 +26,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rivian/delta-go/lock/filelock"
+	"github.com/rivian/delta-go/state/filestate"
 	"github.com/segmentio/parquet-go"
-	"gitlab.com/rivian/rel/delta-go/lock/filelock"
-	"gitlab.com/rivian/rel/delta-go/state/filestate"
 
-	"gitlab.com/rivian/rel/delta-go/storage"
-	"gitlab.com/rivian/rel/delta-go/storage/filestore"
+	"github.com/rivian/delta-go/storage"
+	"github.com/rivian/delta-go/storage/filestore"
 )
 
 func TestDeltaTransactionPrepareCommit(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gitlab.com/rivian/rel/delta-go
+module github.com/rivian/delta-go
 
 go 1.20
 
@@ -6,6 +6,7 @@ require (
 	cirello.io/dynamolock v1.4.0
 	github.com/aws/aws-sdk-go v1.44.200
 	github.com/aws/aws-sdk-go-v2 v1.17.6
+	github.com/aws/smithy-go v1.13.5
 	github.com/go-redsync/redsync/v4 v4.8.1
 	github.com/gofrs/flock v0.8.1
 	github.com/google/uuid v1.3.0
@@ -26,7 +27,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.25 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.24 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.24 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 )

--- a/internal/s3mock/s3mock.go
+++ b/internal/s3mock/s3mock.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"gitlab.com/rivian/rel/delta-go/storage"
-	"gitlab.com/rivian/rel/delta-go/storage/filestore"
+	"github.com/rivian/delta-go/storage"
+	"github.com/rivian/delta-go/storage/filestore"
 )
 
 type S3MockClient struct {

--- a/lock/dynamolock/dynamolock.go
+++ b/lock/dynamolock/dynamolock.go
@@ -19,7 +19,7 @@ import (
 
 	"cirello.io/dynamolock"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"gitlab.com/rivian/rel/delta-go/lock"
+	"github.com/rivian/delta-go/lock"
 )
 
 type DynamoLock struct {

--- a/lock/filelock/filelock.go
+++ b/lock/filelock/filelock.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
-	"gitlab.com/rivian/rel/delta-go/lock"
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/lock"
+	"github.com/rivian/delta-go/storage"
 )
 
 type FileLock struct {

--- a/lock/filelock/filelock_test.go
+++ b/lock/filelock/filelock_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/storage"
 )
 
 func TestTryLock(t *testing.T) {

--- a/lock/redislock/redislock.go
+++ b/lock/redislock/redislock.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
 	goredislib "github.com/redis/go-redis/v9"
-	"gitlab.com/rivian/rel/delta-go/lock"
+	"github.com/rivian/delta-go/lock"
 )
 
 type RedisLock struct {

--- a/schema.go
+++ b/schema.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/rivian/rel/delta-go/state"
+	"github.com/rivian/delta-go/state"
 )
 
 // / Type alias for a string expected to match a GUID/UUID format

--- a/state/dynamostate/dynamostate.go
+++ b/state/dynamostate/dynamostate.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"gitlab.com/rivian/rel/delta-go/state"
+	"github.com/rivian/delta-go/state"
 )
 
 const KEY string = "key"

--- a/state/dynamostate/dynamostate_test.go
+++ b/state/dynamostate/dynamostate_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
-	"gitlab.com/rivian/rel/delta-go/state"
+	"github.com/rivian/delta-go/state"
 )
 
 type mockDynamoDBClient struct {

--- a/state/filestate/filestate.go
+++ b/state/filestate/filestate.go
@@ -18,8 +18,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"gitlab.com/rivian/rel/delta-go/state"
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/state"
+	"github.com/rivian/delta-go/storage"
 )
 
 type FileStateStore struct {

--- a/state/filestate/filestate_test.go
+++ b/state/filestate/filestate_test.go
@@ -16,8 +16,8 @@ import (
 	"errors"
 	"testing"
 
-	"gitlab.com/rivian/rel/delta-go/state"
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/state"
+	"github.com/rivian/delta-go/storage"
 )
 
 func TestGetPutData(t *testing.T) {

--- a/state/redisstate/rediststate.go
+++ b/state/redisstate/rediststate.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 
 	"github.com/redis/go-redis/v9"
-	"gitlab.com/rivian/rel/delta-go/state"
+	"github.com/rivian/delta-go/state"
 )
 
 type RedisStateStore struct {

--- a/state/redisstate/rediststate_test.go
+++ b/state/redisstate/rediststate_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/rivian/delta-go/state"
 	"github.com/stvp/tempredis"
-	"gitlab.com/rivian/rel/delta-go/state"
 )
 
 var servers []*tempredis.Server

--- a/storage/filestore/filestore.go
+++ b/storage/filestore/filestore.go
@@ -50,10 +50,10 @@ func (s *FileObjectStore) Put(location *storage.Path, bytes []byte) error {
 
 func (s *FileObjectStore) RenameIfNotExists(from *storage.Path, to *storage.Path) error {
 
-	// return ErrorVersionAlreadyExists if the destination file exists
+	// return ErrorObjectAlreadyExists if the destination file exists
 	_, err := s.Head(to)
 	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
-		return fmt.Errorf("error %w: Object at location %s already exists", storage.ErrorVersionAlreadyExists, to.Raw)
+		return fmt.Errorf("error %w: Object at location %s already exists", storage.ErrorObjectAlreadyExists, to.Raw)
 	}
 	// rename source to destination
 	err = s.Rename(from, to)

--- a/storage/filestore/filestore.go
+++ b/storage/filestore/filestore.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/storage"
 )
 
 // FileObjectStore provides local file storage

--- a/storage/filestore/filestore_test.go
+++ b/storage/filestore/filestore_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"testing"
 
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/storage"
 )
 
 func TestPut(t *testing.T) {

--- a/storage/filestore/filestore_test.go
+++ b/storage/filestore/filestore_test.go
@@ -113,7 +113,7 @@ func TestRenameIfNotExists(t *testing.T) {
 
 	//File already exists from previous rename, so err should be storage.ErrorVersionAlreadyExists
 	err = store.RenameIfNotExists(fromPath, toPath)
-	if !errors.Is(err, storage.ErrorVersionAlreadyExists) {
+	if !errors.Is(err, storage.ErrorObjectAlreadyExists) {
 		t.Errorf("err = %e;", err)
 	}
 

--- a/storage/s3store/s3store.go
+++ b/storage/s3store/s3store.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -125,9 +126,10 @@ func (s *S3ObjectStore) Delete(location *storage.Path) error {
 }
 
 func (s *S3ObjectStore) RenameIfNotExists(from *storage.Path, to *storage.Path) error {
+	// return ErrorObjectAlreadyExists if the destination file exists
 	_, err := s.Head(to)
-	if err == nil {
-		return errors.Join(storage.ErrorObjectAlreadyExists, err)
+	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+		return fmt.Errorf("error %w: Object at location %s already exists", storage.ErrorObjectAlreadyExists, to.Raw)
 	}
 
 	err = s.Rename(from, to)

--- a/storage/s3store/s3store.go
+++ b/storage/s3store/s3store.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/storage"
 )
 
 type S3ClientAPI interface {

--- a/storage/s3store/s3store_test.go
+++ b/storage/s3store/s3store_test.go
@@ -22,8 +22,8 @@ import (
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"gitlab.com/rivian/rel/delta-go/internal/s3mock"
-	"gitlab.com/rivian/rel/delta-go/storage"
+	"github.com/rivian/delta-go/internal/s3mock"
+	"github.com/rivian/delta-go/storage"
 )
 
 // Test helper: setupTest does common setup for our tests, creating a mock S3 client and an S3ObjectStore

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,17 +22,16 @@ import (
 )
 
 var (
-	ErrorVersionAlreadyExists error = errors.New("the commit version already exists")
-	ErrorObjectAlreadyExists  error = errors.New("the object already exists")
-	ErrorObjectDoesNotExist   error = errors.New("the object does not exist")
-	ErrorObjectIsDir          error = errors.New("the object is a directory")
-	ErrorCopyObject           error = errors.New("error while copying the object")
-	ErrorPutObject            error = errors.New("error while putting the object")
-	ErrorGetObject            error = errors.New("error while getting the object")
-	ErrorHeadObject           error = errors.New("error while getting the object head")
-	ErrorDeleteObject         error = errors.New("error while deleting the object")
-	ErrorURLJoinPath          error = errors.New("error during url.JoinPath")
-	ErrorListObjects          error = errors.New("error while listing objects")
+	ErrorObjectAlreadyExists error = errors.New("the object already exists")
+	ErrorObjectDoesNotExist  error = errors.New("the object does not exist")
+	ErrorObjectIsDir         error = errors.New("the object is a directory")
+	ErrorCopyObject          error = errors.New("error while copying the object")
+	ErrorPutObject           error = errors.New("error while putting the object")
+	ErrorGetObject           error = errors.New("error while getting the object")
+	ErrorHeadObject          error = errors.New("error while getting the object head")
+	ErrorDeleteObject        error = errors.New("error while deleting the object")
+	ErrorURLJoinPath         error = errors.New("error during url.JoinPath")
+	ErrorListObjects         error = errors.New("error while listing objects")
 )
 
 type DeltaStorageResult struct {


### PR DESCRIPTION
- removed `storage.ErrorVersionAlreadyExists` updated the condition for transaction.TryCommitLoop to retry on `ErrorObjectAlreadyExists`
- Updated gitlab.com/rivian/rel to github.com/rivian