### PR TITLE
Updated Create.GetCommitInfo() to properly handel partitionBy json value

### DIFF
--- a/action.go
+++ b/action.go
@@ -276,7 +276,7 @@ type Write struct {
 	/// The columns the write is partitioned by.
 	PartitionBy []string `json:"partitionBy"`
 	/// The predicate used during the write.
-	Predicate string `json:"predicate,omitempty"`
+	Predicate []string `json:"predicate"`
 }
 
 func (op Write) GetCommitInfo() CommitInfo {
@@ -291,13 +291,17 @@ func (op Write) GetCommitInfo() CommitInfo {
 		partitionByJSON = []byte("[]")
 	}
 
+	// convert PartitionBy to JSON string, return "[]" if empty
+	predicateJSON, _ := json.Marshal(op.Predicate)
+	if len(op.Predicate) == 0 {
+		predicateJSON = []byte("[]")
+	}
+
 	// add operation parameters to map
 	operationParams := make(map[string]interface{})
 	operationParams["mode"] = op.Mode
 	operationParams["partitionBy"] = string(partitionByJSON)
-	if op.Predicate != "" {
-		operationParams["predicate"] = op.Predicate
-	}
+	operationParams["predicate"] = string(predicateJSON)
 
 	// add operation parameters map to commitInfo
 	commitInfo["operationParameters"] = operationParams

--- a/action_test.go
+++ b/action_test.go
@@ -50,7 +50,7 @@ func TestLogEntryFromActions(t *testing.T) {
 	}
 	println(string(logs))
 
-	expectedStr := `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"timestamp":1675020556534}}
+	expectedStr := `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]","predicate":"[]"},"timestamp":1675020556534}}
 	{"add":{"path":"part-1.snappy.parquet","size":1,"partitionValues":null,"modificationTime":{},"dataChange":false,"stats":"","Tags":null}}
 	{"path":"part-2.snappy.parquet","size":2,"partitionValues":null,"modificationTime":{},"dataChange":false,"stats":"","Tags":null}`
 
@@ -58,7 +58,7 @@ func TestLogEntryFromActions(t *testing.T) {
 		t.Errorf("want:\n%s\nhas:\n%s\n", expectedStr, string(logs))
 	}
 
-	if !strings.Contains(string(logs), `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]"},"timestamp":1675020556534}}`) {
+	if !strings.Contains(string(logs), `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"ErrorIfExists","partitionBy":"[]","predicate":"[]"},"timestamp":1675020556534}}`) {
 		t.Errorf("want:\n%s\nhas:\n%s\n", expectedStr, string(logs))
 	}
 
@@ -196,7 +196,7 @@ func TestWriteOperationParameters(t *testing.T) {
 		t.Error(err)
 	}
 	println(string(logs))
-	expectedStr := `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"Append","partitionBy":"[\"date\"]"},"timestamp":1675020556534}}`
+	expectedStr := `{"commitInfo":{"operation":"delta-go.Write","operationParameters":{"mode":"Append","partitionBy":"[\"date\"]","predicate":"[]"},"timestamp":1675020556534}}`
 
 	// compare the JSON strings
 	if !reflect.DeepEqual(expectedStr, string(logs)) {
@@ -209,8 +209,8 @@ func TestWrite_GetCommitInfo(t *testing.T) {
 	// create a new Write struct
 	write := Write{
 		Mode:        Append,
-		PartitionBy: []string{"date"},
-		Predicate:   "col = 'value'",
+		PartitionBy: []string{"id", "date"},
+		Predicate:   []string{"col = 'value'"},
 	}
 
 	// call GetCommitInfo()
@@ -221,8 +221,8 @@ func TestWrite_GetCommitInfo(t *testing.T) {
 		"operation": "delta-go.Write",
 		"operationParameters": map[string]interface{}{
 			"mode":        "Append",
-			"partitionBy": "[\"date\"]",
-			"predicate":   "col = 'value'",
+			"partitionBy": "[\"id\",\"date\"]",
+			"predicate":   "[\"col = 'value'\"]",
 		},
 	}
 
@@ -241,7 +241,7 @@ func TestWrite_GetCommitInfoEmptyPartitionBy(t *testing.T) {
 	write := Write{
 		Mode: Append,
 		// PartitionBy: []string{""},
-		Predicate: "col = 'value'",
+		// Predicate: []"col = 'value'",
 	}
 
 	// call GetCommitInfo()
@@ -253,7 +253,7 @@ func TestWrite_GetCommitInfoEmptyPartitionBy(t *testing.T) {
 		"operationParameters": map[string]interface{}{
 			"mode":        "Append",
 			"partitionBy": "[]",
-			"predicate":   "col = 'value'",
+			"predicate":   "[]",
 		},
 	}
 


### PR DESCRIPTION
The prior version was pushing the Create operationParameters as a dictionary, the expected values should be json.

old: `"operationParameters":{"mode":"Append","partitionBy":["date"], "predicate": null}`
new: `"operationParameters":{"mode":"Append","partitionBy":"[\"date\"]", "predicate": "[]"}`

In production, we were seeing this error:
```
java.util.concurrent.ExecutionException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`)
 at [Source: (String)"{"commitInfo":{"clientVersion":"delta-go.alpha-0.0.0","isBlindAppend":true,"operation":"delta-go.Write","operationParameters":{"mode":"Append","partitionBy":["date"],"Predicate":""},"timestamp":1680899747050}}"; line: 1, column: 158] (through reference chain: com.databricks.sql.transaction.tahoe.actions.SingleAction["commitInfo"]->com.databricks.sql.transaction.tahoe.actions.CommitInfo["operationParameters"]->com.fasterxml.jackson.module.scala.deser.GenericMapFactoryDeserializerResolver$BuilderWrapper["partitionBy"])
```

