### PR TITLE
List() in storage is now paged; ListAll() does paging for you

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ go.work
 
 # Redis snapshot used in tests
 dump.rdb
+
+.DS_Store
+.vscode

--- a/action.go
+++ b/action.go
@@ -266,6 +266,9 @@ func ActionsFromLogEntries(logEntries []byte) ([]Action, error) {
 	lines := bytes.Split(logEntries, []byte("\n"))
 	actions := make([]Action, 0, len(lines))
 	for _, currentLine := range lines {
+		if len(currentLine) == 0 {
+			continue
+		}
 		var unstructuredResult map[string]json.RawMessage
 		err := json.Unmarshal(currentLine, &unstructuredResult)
 		if err != nil {

--- a/delta.go
+++ b/delta.go
@@ -152,11 +152,13 @@ func (table *DeltaTable) Exists() (bool, error) {
 	if errors.Is(err, storage.ErrorObjectDoesNotExist) {
 		// Fallback: check for other variants of the version
 		basePath := table.BaseCommitUri()
-		results, err := table.Store.List(basePath)
+		// Do not use paged result; if we aren't seeing a version file in the
+		// first page of results, it's very unlikely that this is a commit log folder
+		results, err := table.Store.List(basePath, nil)
 		if err != nil {
 			return false, err
 		}
-		for _, result := range results {
+		for _, result := range results.Objects {
 			// Check each result to see if it is a version file
 			isValidCommitUri, err := table.IsValidCommitUri(&result.Location)
 			if err != nil {

--- a/internal/s3mock/s3mock.go
+++ b/internal/s3mock/s3mock.go
@@ -176,16 +176,17 @@ func (m *S3MockClient) ListObjectsV2(ctx context.Context, input *s3.ListObjectsV
 		return nil, err
 	}
 
-	output, err := m.fileStore.List(prefix)
+	output, err := m.fileStore.List(prefix, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	listObjectsOutput := new(s3.ListObjectsV2Output)
-	listObjectsOutput.Contents = make([]types.Object, 0, len(output))
-	for _, r := range output {
-		key := strings.TrimPrefix(r.Location.Raw, *input.Bucket)
-		if key != m.s3StorePath {
+	listObjectsOutput.Contents = make([]types.Object, 0, len(output.Objects))
+	trimmedStorePath := strings.TrimPrefix(m.s3StorePath, "/")
+	for _, r := range output.Objects {
+		key := strings.TrimPrefix(r.Location.Raw, *input.Bucket+"/")
+		if key != trimmedStorePath {
 			lastModified := r.LastModified
 			listObjectsOutput.Contents = append(listObjectsOutput.Contents, types.Object{
 				Key:          &key,

--- a/storage/filestore/filestore_test.go
+++ b/storage/filestore/filestore_test.go
@@ -226,12 +226,19 @@ func TestList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := store.List(tt.args.prefix)
+			got, err := store.List(tt.args.prefix, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FileObjectStore.List() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			compareExpectedPaths(t, tt.want, got)
+			compareExpectedPaths(t, tt.want, got.Objects)
+			got, err = store.ListAll(tt.args.prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FileObjectStore.List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			compareExpectedPaths(t, tt.want, got.Objects)
+
 		})
 	}
 }

--- a/storage/s3store/s3store_test.go
+++ b/storage/s3store/s3store_test.go
@@ -449,12 +449,20 @@ func TestList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := store.List(tt.args.prefix)
+			got, err := store.List(tt.args.prefix, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FileObjectStore.List() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			compareExpectedPaths(t, tt.want, got)
+			compareExpectedPaths(t, tt.want, got.Objects)
+		})
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := store.ListAll(tt.args.prefix)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FileObjectStore.ListAll() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			compareExpectedPaths(t, tt.want, got.Objects)
 		})
 	}
 }
@@ -465,7 +473,11 @@ func TestListErrorHandling(t *testing.T) {
 	// Test client returning an error
 	mockClient.MockError = errors.New("Something went wrong")
 	path := storage.NewPath("data.txt")
-	_, err := store.List(path)
+	_, err := store.List(path, nil)
+	if !errors.Is(err, storage.ErrorListObjects) {
+		t.Errorf("Delete did not return an expected error")
+	}
+	_, err = store.ListAll(path)
 	if !errors.Is(err, storage.ErrorListObjects) {
 		t.Errorf("Delete did not return an expected error")
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -113,9 +113,10 @@ type ObjectMeta struct {
 // / 1,000 objects based on the underlying object storage's limitations.
 type ListResult struct {
 	/// Prefixes that are common (like directories)
-	CommonPrefixes []Path
+	// CommonPrefixes []Path
 	/// Object metadata for the listing
-	Objects []ObjectMeta
+	Objects   []ObjectMeta
+	NextToken string
 }
 
 // / Lock data which stores an attempt to rename `source` into `destination`
@@ -171,12 +172,23 @@ type ObjectStore interface {
 	// 	/// Delete the object at the specified location.
 	Delete(location *Path) error
 
-	/// List all the objects with the given prefix.  This may be limited to a certain number of objects (e.g. 1000)
+	/// List the objects with the given prefix.  This may be limited to a certain number of objects (e.g. 1000)
 	/// based on the underlying object storage's limitations.
+	/// If a previousResult is provided and the store supports paging, the next page of results will be returned.
 	///
 	/// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
 	/// `foo/bar_baz/x`.
-	List(prefix *Path) ([]ObjectMeta, error)
+	List(prefix *Path, previousResult *ListResult) (ListResult, error)
+
+	/// List all objects with the given prefix. If the underlying object storage returns a limited number of objects,
+	/// this will perform paging as required to return all results
+	///
+	/// Prefixes are evaluated on a path segment basis, i.e. `foo/bar/` is a prefix of `foo/bar/x` but not of
+	/// `foo/bar_baz/x`.
+	ListAll(prefix *Path) (ListResult, error)
+
+	/// Returns true if this store returns list results sorted
+	IsListOrdered() bool
 
 	// 	/// List all the objects with the given prefix.
 	// 	///


### PR DESCRIPTION
The S3 `List()` operation now accepts a continuation token to allow manual paging of results.
`ListAll()` will perform the paging internally and return all results.

I've left `List()` as public after all.  The `DeltaTable` `Exists()` function is using `List()` as a fallback to look for commit log files if version 0 doesn't exist, and it would be a waste of resources to list out everything in the _delta_log folder.

Thanks Rahul for the `ListAll()` implementation!  I restructured it slightly to match `List`.