### PR TITLE
Add nil lock and local statestore

### DIFF
--- a/lock/nillock/nillock.go
+++ b/lock/nillock/nillock.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Rivian Automotive, Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package nillock
+
+import (
+	"github.com/rivian/delta-go/lock"
+)
+
+// / An NilLock implements the Locker interface but is not backed by anything
+// / It is intended for use in a scenario where there is guaranteed to be only one process writing to a delta table
+// / so that locking is not necessary
+// /
+// / WARNING:
+// / It provides NO concurrency support.
+// / It must be used with a single goroutine only.
+// / If used while there are other goroutines or applications (including Spark) writing to the table then
+// / it is likely that commits will be overwritten and lost.
+// / This is intended only for testing, or for use with local tables.
+type NilLock struct {
+}
+
+// Compile time check that NilLock implements lock.Locker
+var _ lock.Locker = (*NilLock)(nil)
+
+func New() *NilLock {
+	return new(NilLock)
+}
+
+// Does nothing
+func (*NilLock) Unlock() error {
+	return nil
+}
+
+// Always returns true
+func (*NilLock) TryLock() (bool, error) {
+	return true, nil
+}

--- a/lock/nillock/nillock_test.go
+++ b/lock/nillock/nillock_test.go
@@ -1,0 +1,25 @@
+package nillock
+
+import "testing"
+
+func TestNilLock(t *testing.T) {
+	nilLock := new(NilLock)
+	locked, err := nilLock.TryLock()
+	if err != nil {
+		t.Error(err)
+	}
+	if !locked {
+		t.Error("NilLock's TryLock should always succeed")
+	}
+	locked, err = nilLock.TryLock()
+	if err != nil {
+		t.Error(err)
+	}
+	if !locked {
+		t.Error("NilLock's TryLock should always succeed")
+	}
+	err = nilLock.Unlock()
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/state/localstate/localstate.go
+++ b/state/localstate/localstate.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Rivian Automotive, Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package localstate
+
+import (
+	"github.com/rivian/delta-go/state"
+)
+
+// / LocalStateStore stores the version locally.
+// / WARNING
+// / There is no concurrency support for multiple goroutines or processes.
+// / There is no persistence.
+// / This is intended for local use and testing only.
+type LocalStateStore struct {
+	version state.DeltaDataTypeVersion
+}
+
+// / Create a new LocalStateStore with the current table version
+func New(currentTableVersion state.DeltaDataTypeVersion) *LocalStateStore {
+	ls := new(LocalStateStore)
+	ls.version = currentTableVersion
+	return ls
+}
+
+// Compile time check that LocalStateStore implements state.StateStore
+var _ state.StateStore = (*LocalStateStore)(nil)
+
+func (stateStore *LocalStateStore) Get() (state.CommitState, error) {
+	return state.CommitState{Version: stateStore.version}, nil
+}
+
+func (stateStore *LocalStateStore) Put(commitState state.CommitState) error {
+	stateStore.version = commitState.Version
+	return nil
+}

--- a/state/localstate/localstate_test.go
+++ b/state/localstate/localstate_test.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Rivian Automotive, Inc.
+// Licensed under the Apache License, Version 2.0 (the “License”);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an “AS IS” BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package localstate
+
+import (
+	"testing"
+
+	"github.com/rivian/delta-go/state"
+)
+
+func TestGetPutVersion(t *testing.T) {
+	localState := new(LocalStateStore)
+
+	err := localState.Put(state.CommitState{Version: 1})
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := localState.Get()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result.Version != 1 {
+		t.Errorf("expected version %d, got %d", 1, result.Version)
+	}
+
+	err = localState.Put(state.CommitState{Version: 200})
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err = localState.Get()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result.Version != 200 {
+		t.Errorf("expected version %d, got %d", 200, result.Version)
+	}
+}


### PR DESCRIPTION
- New lock and state for testing and scripting when we know that there are no concurrent writers:
  - `NilLock` has no actual locking, it just returns true/nil
  - `LocalStateStore` stores the version in memory, with no concurrency protection
- Example of using `NilLock` and `LocalStateStore` is in `TestTryCommitWithNilLockAndLocalState` in `delta_test.go` 

