### PR TITLE
Fix checkpointing without partitions, other checkpointing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,6 @@ Limitations / TODO
 
 Checkpoints:
 - The checkpoint checksum is not being written or validated
-- Checkpoints without partitions are not supported
 - Checkpoints with non-string-type partitions require custom JSON marshal/unmarshal code
 - Parsed stats does not include null counts
 
@@ -256,7 +255,3 @@ Other:
 - Change data files are not supported
 - CDC files are not supported
 - Add stats need to be manually generated instead of being read from the parquet file
-
-Immediate TODO:
-- Warning on min version too high (3/1)
-- Warn if opening a table with versions too high

--- a/action_test.go
+++ b/action_test.go
@@ -29,12 +29,12 @@ type emptyTestStruct struct {
 }
 
 func TestLogEntryFromActions(t *testing.T) {
-	add1 := Add[emptyTestStruct, emptyTestStruct]{
+	add1 := AddPartitioned[emptyTestStruct, emptyTestStruct]{
 		Path:             "part-1.snappy.parquet",
 		Size:             1,
 		ModificationTime: DeltaDataTypeTimestamp(1675020556534),
 	}
-	add2 := &Add[emptyTestStruct, emptyTestStruct]{
+	add2 := &AddPartitioned[emptyTestStruct, emptyTestStruct]{
 		Path:             "part-2.snappy.parquet",
 		Size:             2,
 		ModificationTime: DeltaDataTypeTimestamp(1675020556534),
@@ -331,7 +331,7 @@ func TestActionFromLogEntry(t *testing.T) {
 		wantErr error
 	}{
 		{name: "Add", args: args{unstructuredResult: map[string]json.RawMessage{"add": []byte(`{"path":"mypath.parquet","size":8382,"partitionValues":{"date":"2021-03-09"},"modificationTime":1679610144893,"dataChange":true,"stats":"{\"numRecords\":155,\"tightBounds\":false,\"minValues\":{\"timestamp\":1615338375007003},\"maxValues\":{\"timestamp\":1615338377517216},\"nullCount\":null}"}`)}},
-			want: &Add[emptyTestStruct, emptyTestStruct]{Path: "mypath.parquet", Size: 8382, PartitionValues: map[string]string{"date": "2021-03-09"}, ModificationTime: 1679610144893, DataChange: true,
+			want: &AddPartitioned[emptyTestStruct, emptyTestStruct]{Path: "mypath.parquet", Size: 8382, PartitionValues: map[string]string{"date": "2021-03-09"}, ModificationTime: 1679610144893, DataChange: true,
 				Stats: `{"numRecords":155,"tightBounds":false,"minValues":{"timestamp":1615338375007003},"maxValues":{"timestamp":1615338377517216},"nullCount":null}`}, wantErr: nil},
 		{name: "CommitInfo", args: args{unstructuredResult: map[string]json.RawMessage{"commitInfo": []byte(`{"clientVersion":"delta-go.alpha-0.0.0","isBlindAppend":true,"operation":"delta-go.Write","timestamp":1679610144893}`)}},
 			want: &CommitInfo{"clientVersion": "delta-go.alpha-0.0.0", "isBlindAppend": true, "operation": "delta-go.Write",
@@ -367,7 +367,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 		NumRecords: 123,
 	}
 
-	add := Add[emptyTestStruct, emptyTestStruct]{
+	add := AddPartitioned[emptyTestStruct, emptyTestStruct]{
 		Path:             "part-1.snappy.parquet",
 		Size:             1,
 		ModificationTime: DeltaDataTypeTimestamp(1675020556534),
@@ -408,7 +408,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 		t.Errorf("Commit did not match.  Got %v expected %v", *resultCommit, commit)
 	}
 
-	resultAdd, ok := actions[1].(*Add[emptyTestStruct, emptyTestStruct])
+	resultAdd, ok := actions[1].(*AddPartitioned[emptyTestStruct, emptyTestStruct])
 	if !ok {
 		t.Error("Expected Add for second action")
 	}

--- a/delta.go
+++ b/delta.go
@@ -343,7 +343,7 @@ func (table *DeltaTable[RowType, PartitionType]) findLatestCheckpointsForVersion
 			}
 			// For multi-part checkpoint, verify that all parts are present before using it
 			isCompleteCheckpoint := true
-			if checkpoint.Parts > 0 {
+			if checkpoint.Parts != nil {
 				isCompleteCheckpoint, err = doesCheckpointVersionExist(table.Store, DeltaDataTypeVersion(checkpoint.Version), true)
 				if err != nil {
 					return nil, false, err
@@ -385,10 +385,10 @@ func (table *DeltaTable[RowType, PartitionType]) findLatestCheckpointsForVersion
 func (table *DeltaTable[RowType, PartitionType]) GetCheckpointDataPaths(checkpoint *CheckPoint) []storage.Path {
 	paths := make([]storage.Path, 0, 10)
 	prefix := fmt.Sprintf("%020d", checkpoint.Version)
-	if checkpoint.Parts == 0 {
+	if checkpoint.Parts == nil {
 		paths = append(paths, storage.PathFromIter([]string{"_delta_log", prefix + ".checkpoint.parquet"}))
 	} else {
-		for i := DeltaDataTypeInt(0); i < checkpoint.Parts; i++ {
+		for i := DeltaDataTypeInt(0); i < *checkpoint.Parts; i++ {
 			part := fmt.Sprintf("%s.checkpoint.%010d.%010d.parquet", prefix, i+1, checkpoint.Parts)
 			paths = append(paths, storage.PathFromIter([]string{"_delta_log", part}))
 		}

--- a/delta.go
+++ b/delta.go
@@ -136,7 +136,7 @@ func CommitOrCheckpointVersionFromUri(path *storage.Path) (bool, state.DeltaData
 // / Create a DeltaTable with version 0 given the provided MetaData, Protocol, and CommitInfo
 // / Note that if the protocol MinReaderVersion or MinWriterVersion is too high, the table will be created
 // / and then an error will be returned
-func (table *DeltaTable[RowType, PartitionType]) Create(metadata DeltaTableMetaData, protocol Protocol, commitInfo CommitInfo, addActions []Add[RowType, PartitionType]) error {
+func (table *DeltaTable[RowType, PartitionType]) Create(metadata DeltaTableMetaData, protocol Protocol, commitInfo CommitInfo, addActions []AddPartitioned[RowType, PartitionType]) error {
 	meta := metadata.ToMetaData()
 
 	// delta-rs commit info will include the delta-rs version and timestamp as of now
@@ -852,11 +852,11 @@ func OpenTableWithVersion[RowType any, PartitionType any](store storage.ObjectSt
 	}
 
 	if table.State.MinReaderVersion > MAX_READER_VERSION_SUPPORTED {
-		err = ErrorUnsupportedReaderVersion
+		err = errors.Join(ErrorUnsupportedReaderVersion, fmt.Errorf("table minimum reader version %d, max supported reader version %d", table.State.MinReaderVersion, MAX_READER_VERSION_SUPPORTED))
 	}
 
 	if table.State.MinWriterVersion > MAX_WRITER_VERSION_SUPPORTED {
-		err = errors.Join(err, ErrorUnsupportedWriterVersion)
+		err = errors.Join(err, ErrorUnsupportedWriterVersion, fmt.Errorf("table minimum writer version %d, max supported writer version %d", table.State.MinWriterVersion, MAX_WRITER_VERSION_SUPPORTED))
 	}
 
 	return table, err

--- a/delta_test.go
+++ b/delta_test.go
@@ -130,7 +130,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
 	metadata := NewDeltaTableMetaData("Test Table", "", format, schema, []string{}, config)
-	protocol := Protocol{MinReaderVersion: 2, MinWriterVersion: 6}
+	protocol := Protocol{MinReaderVersion: 1, MinWriterVersion: 3}
 	stats := Stats{NumRecords: 1, MinValues: map[string]any{"first_column": 1}}
 	add := Add[testData, emptyTestStruct]{
 		Path:             "part-123.snappy.parquet",
@@ -360,7 +360,7 @@ func TestDeltaTableCreate(t *testing.T) {
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
 	metadata := NewDeltaTableMetaData("Test Table", "", format, schema, []string{}, config)
-	protocol := Protocol{MinReaderVersion: 2, MinWriterVersion: 7}
+	protocol := Protocol{MinReaderVersion: 1, MinWriterVersion: 3}
 	add := Add[testData, emptyTestStruct]{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
 		Size:             984,

--- a/tablestate.go
+++ b/tablestate.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"strconv"
 	"time"
@@ -110,6 +111,10 @@ func (tableState *DeltaTableState[RowType, PartitionType]) processAction(actionI
 	switch action := actionInterface.(type) {
 	case *Add[RowType, PartitionType]:
 		tableState.Files[action.Path] = *action
+	case *AddWithoutPartition[RowType]:
+		add := new(Add[RowType, PartitionType])
+		add.fromAddWithoutPartition(action)
+		tableState.Files[action.Path] = *add
 	case *Remove:
 		// TODO - do we need to decode as in delta-rs?
 		tableState.Tombstones[action.Path] = *action
@@ -223,8 +228,24 @@ func stateFromCheckpoint[RowType any, PartitionType any](table *DeltaTable[RowTy
 	return newState, nil
 }
 
-// / Update a table state with the contents of a checkpoint file
+func isPartitionTypeEmpty[PartitionType any]() bool {
+	testPartitionItem := new(PartitionType)
+	structType := reflect.TypeOf(*testPartitionItem)
+	return structType.NumField() == 0
+}
+
 func processCheckpointBytes[RowType any, PartitionType any](checkpointBytes []byte, tableState *DeltaTableState[RowType, PartitionType], table *DeltaTable[RowType, PartitionType]) (returnErr error) {
+	// Determine whether partitioned
+	isPartitioned := !isPartitionTypeEmpty[PartitionType]()
+	if isPartitioned {
+		return processCheckpointBytesWithAddSpecified[RowType, PartitionType, Add[RowType, PartitionType]](checkpointBytes, tableState, table)
+	} else {
+		return processCheckpointBytesWithAddSpecified[RowType, PartitionType, AddWithoutPartition[RowType]](checkpointBytes, tableState, table)
+	}
+}
+
+// / Update a table state with the contents of a checkpoint file
+func processCheckpointBytesWithAddSpecified[RowType any, PartitionType any, AddType Add[RowType, PartitionType] | AddWithoutPartition[RowType]](checkpointBytes []byte, tableState *DeltaTableState[RowType, PartitionType], table *DeltaTable[RowType, PartitionType]) (returnErr error) {
 	reader := bytes.NewReader(checkpointBytes)
 	// The parquet library will panic if the file is malformed or if it can't handle the RowType/PartitionType
 	defer func() {
@@ -236,10 +257,11 @@ func processCheckpointBytes[RowType any, PartitionType any](checkpointBytes []by
 			returnErr = errors.Join(ErrorReadingCheckpoint, err)
 		}
 	}()
-	parquetReader := parquet.NewGenericReader[CheckpointEntry[RowType, PartitionType]](reader)
+
+	parquetReader := parquet.NewGenericReader[CheckpointEntry[RowType, PartitionType, AddType]](reader)
 	defer parquetReader.Close()
 	for {
-		rowBuffer := make([]CheckpointEntry[RowType, PartitionType], 10)
+		rowBuffer := make([]CheckpointEntry[RowType, PartitionType, AddType], 10)
 		count, err := parquetReader.Read(rowBuffer)
 		doneReading := errors.Is(err, io.EOF)
 		if err != nil && !doneReading {
@@ -310,12 +332,12 @@ func (tableState *DeltaTableState[RowType, PartitionType]) prepareStateForCheckp
 }
 
 // / Retrieve the next batch of checkpoint entries to write to Parquet
-func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startOffset int, maxRows int) ([]CheckpointEntry[RowType, PartitionType], error) {
+func checkpointRows[RowType any, PartitionType any, AddType Add[RowType, PartitionType] | AddWithoutPartition[RowType]](tableState *DeltaTableState[RowType, PartitionType], startOffset int, maxRows int) ([]CheckpointEntry[RowType, PartitionType, AddType], error) {
 	maxRowCount := 2 + len(tableState.AppTransactionVersion) + len(tableState.Tombstones) + len(tableState.Files)
 	if maxRows < maxRowCount {
 		maxRowCount = maxRows
 	}
-	checkpointRows := make([]CheckpointEntry[RowType, PartitionType], 0, maxRowCount)
+	checkpointRows := make([]CheckpointEntry[RowType, PartitionType, AddType], 0, maxRowCount)
 
 	currentOffset := 0
 
@@ -324,7 +346,7 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 		protocol := new(Protocol)
 		protocol.MinReaderVersion = tableState.MinReaderVersion
 		protocol.MinWriterVersion = tableState.MinWriterVersion
-		checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType]{Protocol: protocol})
+		checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType, AddType]{Protocol: protocol})
 	}
 
 	currentOffset++
@@ -332,7 +354,7 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 	// Row 2: metadata
 	if startOffset <= currentOffset && len(checkpointRows) < maxRows {
 		metadata := tableState.CurrentMetadata.ToMetaData()
-		checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType]{MetaData: &metadata})
+		checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType, AddType]{MetaData: &metadata})
 	}
 
 	currentOffset++
@@ -349,7 +371,7 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 				txn := new(Txn)
 				txn.AppId = appId
 				txn.Version = DeltaDataTypeVersion(tableState.AppTransactionVersion[appId])
-				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType]{Txn: txn})
+				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType, AddType]{Txn: txn})
 
 				if len(checkpointRows) >= maxRows {
 					break
@@ -371,7 +393,7 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 			if startOffset <= currentOffset+i {
 				checkpointRemove := new(Remove)
 				*checkpointRemove = tableState.Tombstones[path]
-				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType]{Remove: checkpointRemove})
+				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType, AddType]{Remove: checkpointRemove})
 
 				if len(checkpointRows) >= maxRows {
 					break
@@ -392,11 +414,11 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 		for i, path := range keys {
 			if startOffset <= currentOffset+i {
 				add := tableState.Files[path]
-				checkpointAdd, err := checkpointAdd(&add)
+				checkpointAdd, err := checkpointAdd[RowType, PartitionType, AddType](&add)
 				if err != nil {
 					return nil, errors.Join(ErrorConvertingCheckpointAdd, err)
 				}
-				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType]{Add: checkpointAdd})
+				checkpointRows = append(checkpointRows, CheckpointEntry[RowType, PartitionType, AddType]{Add: checkpointAdd})
 
 				if len(checkpointRows) >= maxRows {
 					break
@@ -409,7 +431,7 @@ func (tableState *DeltaTableState[RowType, PartitionType]) checkpointRows(startO
 }
 
 // / Convert a slice of checkpoint entries into a checkpoint parquet file and return the bytes
-func checkpointParquetBytes[RowType any, PartitionType any](checkpointRows []CheckpointEntry[RowType, PartitionType]) ([]byte, error) {
+func checkpointParquetBytes[RowType any, PartitionType any, AddType Add[RowType, PartitionType] | AddWithoutPartition[RowType]](checkpointRows []CheckpointEntry[RowType, PartitionType, AddType]) ([]byte, error) {
 	// TODO configuration option for writer batch size?
 	batchSize := 5000
 	startRecord := 0
@@ -418,7 +440,7 @@ func checkpointParquetBytes[RowType any, PartitionType any](checkpointRows []Che
 
 	buf := new(bytes.Buffer)
 	// TODO configuration option for compression type?
-	writer := parquet.NewGenericWriter[CheckpointEntry[RowType, PartitionType]](buf, parquet.Compression(&parquet.Snappy))
+	writer := parquet.NewGenericWriter[CheckpointEntry[RowType, PartitionType, AddType]](buf, parquet.Compression(&parquet.Snappy))
 
 	for totalWritten < totalRecords {
 		endRecord := startRecord + batchSize


### PR DESCRIPTION
This splits the `Add` action into two variants, `Add` and `AddWithPartition`.  `Add` doesn't have the `PartitionValuesParsed` field.  Using this fixes the problem where we can't checkpoint without partitions, because `PartitionValuesParsed` would be an empty struct and parquet doesn't allow empty nested schemas.

Also we now return errors on `Create`, `OpenTable` and `OpenTableWithVersion` when the min reader or min writer version is greater than we support, although the operations still succeed.

Additional fixes:
- add json names for `_last_checkpoint` serialization/deserialization
- fix what is written to the `size` field in `_last_checkpoint` (I've also filed a bug in delta-rs)
- omit `parts` field from `_last_checkpoint` for single part checkpoints