### PR TITLE
Set null counts to zero instead of leaving blank

### DIFF
--- a/action.go
+++ b/action.go
@@ -487,10 +487,14 @@ func StatsFromJson(b []byte) (*Stats, error) {
 func UpdateStats[T constraints.Ordered](s *Stats, k string, vpt *T) {
 
 	var v T
+	if s.NullCount == nil {
+		s.NullCount = make(map[string]int64)
+	}
+	if _, hasPriorNullCount := s.NullCount[k]; !hasPriorNullCount {
+		s.NullCount[k] = 0
+	}
+
 	if vpt == nil {
-		if s.NullCount == nil {
-			s.NullCount = make(map[string]int64)
-		}
 		s.NullCount[k]++
 		//Value is nil, skip applying MinValues, MaxValues
 		return

--- a/action_test.go
+++ b/action_test.go
@@ -169,7 +169,7 @@ func TestUpdateStats(t *testing.T) {
 	}
 
 	b, _ := json.Marshal(stats)
-	expectedStr := `{"numRecords":4,"tightBounds":false,"minValues":{"id":0,"label":"row0","value":1.23},"maxValues":{"id":3,"label":"row3","value":2.13},"nullCount":{"value":2}}`
+	expectedStr := `{"numRecords":4,"tightBounds":false,"minValues":{"id":0,"label":"row0","value":1.23},"maxValues":{"id":3,"label":"row3","value":2.13},"nullCount":{"id":0,"label":0,"value":2}}`
 	statsString := string(b)
 	if statsString != expectedStr {
 		t.Errorf("has:\n%s\nwant:\n%s", statsString, expectedStr)


### PR DESCRIPTION
The DataSkippingReader in Spark requires the null count be set.