### PR TITLE
fix: use complete DynamoDB mock in dynamostate package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-  - package-ecosystem: GitHub-actions
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily

--- a/state/dynamostate/dynamostate.go
+++ b/state/dynamostate/dynamostate.go
@@ -25,14 +25,14 @@ import (
 )
 
 // Represents attribute names in DynamoDB items
-type AttributeName string
+type Attribute string
 
 const (
-	KeyAttr                            AttributeName = "key"
-	VersionAttr                        AttributeName = "version"
-	DefaultMaxRetryTableCreateAttempts uint16        = 20
-	DefaultRCU                         int64         = 5
-	DefaultWCU                         int64         = 5
+	KeyAttr                            Attribute = "key"
+	VersionAttr                        Attribute = "version"
+	DefaultMaxRetryTableCreateAttempts uint16    = 20
+	DefaultRCU                         int64     = 5
+	DefaultWCU                         int64     = 5
 )
 
 type DynamoState struct {

--- a/state/dynamostate/dynamostate.go
+++ b/state/dynamostate/dynamostate.go
@@ -28,8 +28,8 @@ import (
 type Attribute string
 
 const (
-	KeyAttr                            Attribute = "key"
-	VersionAttr                        Attribute = "version"
+	Key                                Attribute = "key"
+	Version                            Attribute = "version"
 	DefaultMaxRetryTableCreateAttempts uint16    = 20
 	DefaultRCU                         int64     = 5
 	DefaultWCU                         int64     = 5
@@ -69,7 +69,7 @@ func New(client dynamodbutils.DynamoDBClient, tableName string, key string, opts
 	createTableInput := dynamodb.CreateTableInput{
 		KeySchema: []types.KeySchemaElement{
 			{
-				AttributeName: aws.String(string(KeyAttr)),
+				AttributeName: aws.String(string(Key)),
 				KeyType:       types.KeyTypeHash,
 			},
 		},
@@ -92,7 +92,7 @@ func (l *DynamoState) Get() (state.CommitState, error) {
 	input := &dynamodb.GetItemInput{
 		TableName: aws.String(l.Table),
 		Key: map[string]types.AttributeValue{
-			string(KeyAttr): &types.AttributeValueMemberS{Value: l.Key},
+			string(Key): &types.AttributeValueMemberS{Value: l.Key},
 		},
 	}
 
@@ -109,7 +109,7 @@ func (l *DynamoState) Get() (state.CommitState, error) {
 		return state.CommitState{Version: -1}, err
 	}
 
-	versionValue := result.Item[string(VersionAttr)].(*types.AttributeValueMemberS).Value
+	versionValue := result.Item[string(Version)].(*types.AttributeValueMemberS).Value
 	version, err := strconv.Atoi(versionValue)
 	if err != nil {
 		//TODO wrap error rather than printing
@@ -128,8 +128,8 @@ func (l *DynamoState) Put(commitS state.CommitState) error {
 	input := &dynamodb.PutItemInput{
 		TableName: aws.String(l.Table),
 		Item: map[string]types.AttributeValue{
-			string(KeyAttr):     &types.AttributeValueMemberS{Value: l.Key},
-			string(VersionAttr): &types.AttributeValueMemberS{Value: versionString},
+			string(Key):     &types.AttributeValueMemberS{Value: l.Key},
+			string(Version): &types.AttributeValueMemberS{Value: versionString},
 		},
 	}
 

--- a/state/dynamostate/dynamostate_test.go
+++ b/state/dynamostate/dynamostate_test.go
@@ -27,7 +27,7 @@ func TestGet(t *testing.T) {
 	}
 	commitS, err := dynamoState.Get()
 	if err != nil {
-		t.Errorf("Error occurred in retrieving  version.")
+		t.Errorf("Error occurred in retrieving version.")
 	}
 	versionString := fmt.Sprintf("%v", commitS.Version)
 	if len(string(versionString)) < 1 {

--- a/state/dynamostate/dynamostate_test.go
+++ b/state/dynamostate/dynamostate_test.go
@@ -16,47 +16,18 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+	"github.com/rivian/delta-go/internal/dynamodbutils"
 	"github.com/rivian/delta-go/state"
 )
 
-type mockDynamoDBClient struct {
-	dynamodbiface.DynamoDBAPI
-}
-
-func (m *mockDynamoDBClient) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
-	return nil, nil
-}
-
-func (m *mockDynamoDBClient) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
-	return &dynamodb.GetItemOutput{
-		Item: map[string]*dynamodb.AttributeValue{
-			"version": {
-				S: aws.String("0"),
-			},
-		},
-	}, nil
-}
-
-// Create a function to return the mock client
-func createMockDynamoDBClient() *mockDynamoDBClient {
-	return &mockDynamoDBClient{}
-}
-
 func TestGet(t *testing.T) {
-	// svc, err := dynamolock.GetDynamoDBClient()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-	dynamoState, err := New(createMockDynamoDBClient(), "storage-table", "_commit.state")
+	dynamoState, err := New(dynamodbutils.NewMockClient(), "storage-table", "_commit.state", Options{})
 	if err != nil {
-		t.Errorf("Error occurred in retriving  version.")
+		t.Errorf("Error occurred in retrieving version.")
 	}
 	commitS, err := dynamoState.Get()
 	if err != nil {
-		t.Errorf("Error occurred in retriving  version.")
+		t.Errorf("Error occurred in retrieving  version.")
 	}
 	versionString := fmt.Sprintf("%v", commitS.Version)
 	if len(string(versionString)) < 1 {
@@ -65,9 +36,9 @@ func TestGet(t *testing.T) {
 }
 
 func TestPut(t *testing.T) {
-	dynamoState, err := New(createMockDynamoDBClient(), "storage-table", "_commit.state")
+	dynamoState, err := New(dynamodbutils.NewMockClient(), "storage-table", "_commit.state", Options{})
 	if err != nil {
-		t.Errorf("Error occurred in retriving  version.")
+		t.Errorf("Error occurred in retrieving version.")
 	}
 	commitState := state.CommitState{Version: 0}
 	err = dynamoState.Put(commitState)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Use the complete DynamoDB mock in `dynamostate` package.
- Remove the DynamoDB mock defined in `dynamostate_test.go`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
