### PR TITLE
fix: use Attribute type for constants in DynamoDB log store

### DIFF
--- a/logstore/dynamodblogstore/dynamodblogstore.go
+++ b/logstore/dynamodblogstore/dynamodblogstore.go
@@ -34,15 +34,15 @@ var (
 )
 
 // Represents attribute names in DynamoDB items
-type AttributeName string
+type Attribute string
 
 const (
 	// DynamoDB table attribute keys
-	TablePathAttr  AttributeName = "tablePath"
-	FileNameAttr   AttributeName = "fileName"
-	TempPathAttr   AttributeName = "tempPath"
-	CompleteAttr   AttributeName = "complete"
-	ExpireTimeAttr AttributeName = "expireTime"
+	TablePathAttr  Attribute = "tablePath"
+	FileNameAttr   Attribute = "fileName"
+	TempPathAttr   Attribute = "tempPath"
+	CompleteAttr   Attribute = "complete"
+	ExpireTimeAttr Attribute = "expireTime"
 
 	// The delay, in seconds, after a commit entry has been committed to the delta log at which
 	// point it is safe to be deleted from the log store.

--- a/logstore/dynamodblogstore/dynamodblogstore.go
+++ b/logstore/dynamodblogstore/dynamodblogstore.go
@@ -33,13 +33,16 @@ var (
 	ErrorUnableToGetCommitEntry error             = errors.New("unable to get commit entry")
 )
 
+// Represents attribute names in DynamoDB items
+type AttributeName string
+
 const (
 	// DynamoDB table attribute keys
-	AttrTablePath  string = "tablePath"
-	AttrFileName   string = "fileName"
-	AttrTempPath   string = "tempPath"
-	AttrComplete   string = "complete"
-	AttrExpireTime string = "expireTime"
+	TablePathAttr  AttributeName = "tablePath"
+	FileNameAttr   AttributeName = "fileName"
+	TempPathAttr   AttributeName = "tempPath"
+	CompleteAttr   AttributeName = "complete"
+	ExpireTimeAttr AttributeName = "expireTime"
 
 	// The delay, in seconds, after a commit entry has been committed to the delta log at which
 	// point it is safe to be deleted from the log store.
@@ -176,21 +179,21 @@ func NewDynamoDBLogStore(lso DynamoDBLogStoreOptions) (*DynamoDBLogStore, error)
 	createTableInput := dynamodb.CreateTableInput{
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
-				AttributeName: aws.String(AttrTablePath),
+				AttributeName: aws.String(string(TablePathAttr)),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String(AttrFileName),
+				AttributeName: aws.String(string(FileNameAttr)),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		KeySchema: []types.KeySchemaElement{
 			{
-				AttributeName: aws.String(AttrTablePath),
+				AttributeName: aws.String(string(TablePathAttr)),
 				KeyType:       types.KeyTypeHash,
 			},
 			{
-				AttributeName: aws.String(AttrFileName),
+				AttributeName: aws.String(string(FileNameAttr)),
 				KeyType:       types.KeyTypeRange,
 			},
 		},
@@ -222,7 +225,7 @@ func (ls *DynamoDBLogStore) Put(entry *logstore.CommitEntry, overwrite bool) err
 
 // Gets an entry corresponding to the Delta log file with given `tablePath` and `fileName` from a DynamoDBLogStore instance
 func (ls *DynamoDBLogStore) Get(tablePath *storage.Path, fileName *storage.Path) (*logstore.CommitEntry, error) {
-	attributes := map[string]types.AttributeValue{AttrTablePath: &types.AttributeValueMemberS{Value: tablePath.Raw}, AttrFileName: &types.AttributeValueMemberS{Value: fileName.Raw}}
+	attributes := map[string]types.AttributeValue{string(TablePathAttr): &types.AttributeValueMemberS{Value: tablePath.Raw}, string(FileNameAttr): &types.AttributeValueMemberS{Value: fileName.Raw}}
 
 	gii := dynamodb.GetItemInput{Key: attributes, TableName: aws.String(ls.tableName), ConsistentRead: aws.Bool(true)}
 	gio, err := ls.client.GetItem(context.TODO(), &gii)
@@ -244,7 +247,7 @@ func (ls *DynamoDBLogStore) Get(tablePath *storage.Path, fileName *storage.Path)
 func (ls *DynamoDBLogStore) GetLatest(tablePath *storage.Path) (*logstore.CommitEntry, error) {
 	qi := dynamodb.QueryInput{TableName: &ls.tableName, ConsistentRead: aws.Bool(true), ScanIndexForward: aws.Bool(false), Limit: aws.Int32(1), ExpressionAttributeValues: map[string]types.AttributeValue{
 		":partitionKey": &types.AttributeValueMemberS{Value: tablePath.Raw},
-	}, KeyConditionExpression: aws.String(fmt.Sprintf("%s = :partitionKey", AttrTablePath))}
+	}, KeyConditionExpression: aws.String(fmt.Sprintf("%s = :partitionKey", TablePathAttr))}
 	qo, err := ls.client.Query(context.TODO(), &qi)
 	if err != nil {
 		log.Debugf("delta-go: Failed Query. %v", err)
@@ -265,11 +268,11 @@ func (ls *DynamoDBLogStore) dbResultToCommitEntry(item map[string]types.Attribut
 	var expireTimeAttr uint64
 	var err error
 
-	_, ok := item[AttrExpireTime]
+	_, ok := item[string(ExpireTimeAttr)]
 	if !ok {
 		expireTimeAttr = 0
 	} else {
-		expireTimeAttr, err = strconv.ParseUint(item[AttrExpireTime].(*types.AttributeValueMemberN).Value, 10, 64)
+		expireTimeAttr, err = strconv.ParseUint(item[string(ExpireTimeAttr)].(*types.AttributeValueMemberN).Value, 10, 64)
 		if err != nil {
 			log.Debugf("delta-go: Failed to interpet expire time attribute as uint64. %v", err)
 			return nil, err
@@ -277,20 +280,20 @@ func (ls *DynamoDBLogStore) dbResultToCommitEntry(item map[string]types.Attribut
 	}
 
 	return logstore.NewCommitEntry(
-		*storage.NewPath(item[AttrTablePath].(*types.AttributeValueMemberS).Value),
-		*storage.NewPath(item[AttrFileName].(*types.AttributeValueMemberS).Value),
-		*storage.NewPath(item[AttrTempPath].(*types.AttributeValueMemberS).Value),
-		item[AttrComplete].(*types.AttributeValueMemberS).Value == "true",
+		*storage.NewPath(item[string(TablePathAttr)].(*types.AttributeValueMemberS).Value),
+		*storage.NewPath(item[string(FileNameAttr)].(*types.AttributeValueMemberS).Value),
+		*storage.NewPath(item[string(TempPathAttr)].(*types.AttributeValueMemberS).Value),
+		item[string(CompleteAttr)].(*types.AttributeValueMemberS).Value == "true",
 		expireTimeAttr,
 	)
 }
 
 // Creates a put item request for an item to be inserted into a DynamoDBLogStore instance
 func (ls *DynamoDBLogStore) createPutItemRequest(entry *logstore.CommitEntry, overwrite bool) (*dynamodb.PutItemInput, error) {
-	attributes := map[string]types.AttributeValue{AttrTablePath: &types.AttributeValueMemberS{Value: entry.TablePath.Raw}, AttrFileName: &types.AttributeValueMemberS{Value: entry.FileName.Raw}, AttrTempPath: &types.AttributeValueMemberS{Value: entry.TempPath.Raw}, AttrComplete: &types.AttributeValueMemberS{Value: *aws.String(strconv.FormatBool(entry.Complete))}}
+	attributes := map[string]types.AttributeValue{string(TablePathAttr): &types.AttributeValueMemberS{Value: entry.TablePath.Raw}, string(FileNameAttr): &types.AttributeValueMemberS{Value: entry.FileName.Raw}, string(TempPathAttr): &types.AttributeValueMemberS{Value: entry.TempPath.Raw}, string(CompleteAttr): &types.AttributeValueMemberS{Value: *aws.String(strconv.FormatBool(entry.Complete))}}
 
 	if entry.ExpireTime != 0 {
-		attributes[AttrExpireTime] = &types.AttributeValueMemberN{Value: *aws.String(fmt.Sprint(entry.ExpireTime))}
+		attributes[string(ExpireTimeAttr)] = &types.AttributeValueMemberN{Value: *aws.String(fmt.Sprint(entry.ExpireTime))}
 	}
 
 	pir := &dynamodb.PutItemInput{
@@ -298,7 +301,7 @@ func (ls *DynamoDBLogStore) createPutItemRequest(entry *logstore.CommitEntry, ov
 		Item:      attributes}
 
 	if !overwrite {
-		pir.ConditionExpression = aws.String(fmt.Sprintf("attribute_not_exists(%s)", AttrFileName))
+		pir.ConditionExpression = aws.String(fmt.Sprintf("attribute_not_exists(%s)", string(FileNameAttr)))
 	}
 
 	return pir, nil

--- a/logstore/dynamodblogstore/dynamodblogstore.go
+++ b/logstore/dynamodblogstore/dynamodblogstore.go
@@ -38,11 +38,11 @@ type Attribute string
 
 const (
 	// DynamoDB table attribute keys
-	TablePathAttr  Attribute = "tablePath"
-	FileNameAttr   Attribute = "fileName"
-	TempPathAttr   Attribute = "tempPath"
-	CompleteAttr   Attribute = "complete"
-	ExpireTimeAttr Attribute = "expireTime"
+	TablePath  Attribute = "tablePath"
+	FileName   Attribute = "fileName"
+	TempPath   Attribute = "tempPath"
+	Complete   Attribute = "complete"
+	ExpireTime Attribute = "expireTime"
 
 	// The delay, in seconds, after a commit entry has been committed to the delta log at which
 	// point it is safe to be deleted from the log store.
@@ -179,21 +179,21 @@ func NewDynamoDBLogStore(lso DynamoDBLogStoreOptions) (*DynamoDBLogStore, error)
 	createTableInput := dynamodb.CreateTableInput{
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
-				AttributeName: aws.String(string(TablePathAttr)),
+				AttributeName: aws.String(string(TablePath)),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String(string(FileNameAttr)),
+				AttributeName: aws.String(string(FileName)),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		KeySchema: []types.KeySchemaElement{
 			{
-				AttributeName: aws.String(string(TablePathAttr)),
+				AttributeName: aws.String(string(TablePath)),
 				KeyType:       types.KeyTypeHash,
 			},
 			{
-				AttributeName: aws.String(string(FileNameAttr)),
+				AttributeName: aws.String(string(FileName)),
 				KeyType:       types.KeyTypeRange,
 			},
 		},
@@ -225,7 +225,7 @@ func (ls *DynamoDBLogStore) Put(entry *logstore.CommitEntry, overwrite bool) err
 
 // Gets an entry corresponding to the Delta log file with given `tablePath` and `fileName` from a DynamoDBLogStore instance
 func (ls *DynamoDBLogStore) Get(tablePath *storage.Path, fileName *storage.Path) (*logstore.CommitEntry, error) {
-	attributes := map[string]types.AttributeValue{string(TablePathAttr): &types.AttributeValueMemberS{Value: tablePath.Raw}, string(FileNameAttr): &types.AttributeValueMemberS{Value: fileName.Raw}}
+	attributes := map[string]types.AttributeValue{string(TablePath): &types.AttributeValueMemberS{Value: tablePath.Raw}, string(FileName): &types.AttributeValueMemberS{Value: fileName.Raw}}
 
 	gii := dynamodb.GetItemInput{Key: attributes, TableName: aws.String(ls.tableName), ConsistentRead: aws.Bool(true)}
 	gio, err := ls.client.GetItem(context.TODO(), &gii)
@@ -247,7 +247,7 @@ func (ls *DynamoDBLogStore) Get(tablePath *storage.Path, fileName *storage.Path)
 func (ls *DynamoDBLogStore) GetLatest(tablePath *storage.Path) (*logstore.CommitEntry, error) {
 	qi := dynamodb.QueryInput{TableName: &ls.tableName, ConsistentRead: aws.Bool(true), ScanIndexForward: aws.Bool(false), Limit: aws.Int32(1), ExpressionAttributeValues: map[string]types.AttributeValue{
 		":partitionKey": &types.AttributeValueMemberS{Value: tablePath.Raw},
-	}, KeyConditionExpression: aws.String(fmt.Sprintf("%s = :partitionKey", TablePathAttr))}
+	}, KeyConditionExpression: aws.String(fmt.Sprintf("%s = :partitionKey", TablePath))}
 	qo, err := ls.client.Query(context.TODO(), &qi)
 	if err != nil {
 		log.Debugf("delta-go: Failed Query. %v", err)
@@ -268,11 +268,11 @@ func (ls *DynamoDBLogStore) dbResultToCommitEntry(item map[string]types.Attribut
 	var expireTimeAttr uint64
 	var err error
 
-	_, ok := item[string(ExpireTimeAttr)]
+	_, ok := item[string(ExpireTime)]
 	if !ok {
 		expireTimeAttr = 0
 	} else {
-		expireTimeAttr, err = strconv.ParseUint(item[string(ExpireTimeAttr)].(*types.AttributeValueMemberN).Value, 10, 64)
+		expireTimeAttr, err = strconv.ParseUint(item[string(ExpireTime)].(*types.AttributeValueMemberN).Value, 10, 64)
 		if err != nil {
 			log.Debugf("delta-go: Failed to interpet expire time attribute as uint64. %v", err)
 			return nil, err
@@ -280,20 +280,20 @@ func (ls *DynamoDBLogStore) dbResultToCommitEntry(item map[string]types.Attribut
 	}
 
 	return logstore.NewCommitEntry(
-		*storage.NewPath(item[string(TablePathAttr)].(*types.AttributeValueMemberS).Value),
-		*storage.NewPath(item[string(FileNameAttr)].(*types.AttributeValueMemberS).Value),
-		*storage.NewPath(item[string(TempPathAttr)].(*types.AttributeValueMemberS).Value),
-		item[string(CompleteAttr)].(*types.AttributeValueMemberS).Value == "true",
+		*storage.NewPath(item[string(TablePath)].(*types.AttributeValueMemberS).Value),
+		*storage.NewPath(item[string(FileName)].(*types.AttributeValueMemberS).Value),
+		*storage.NewPath(item[string(TempPath)].(*types.AttributeValueMemberS).Value),
+		item[string(Complete)].(*types.AttributeValueMemberS).Value == "true",
 		expireTimeAttr,
 	)
 }
 
 // Creates a put item request for an item to be inserted into a DynamoDBLogStore instance
 func (ls *DynamoDBLogStore) createPutItemRequest(entry *logstore.CommitEntry, overwrite bool) (*dynamodb.PutItemInput, error) {
-	attributes := map[string]types.AttributeValue{string(TablePathAttr): &types.AttributeValueMemberS{Value: entry.TablePath.Raw}, string(FileNameAttr): &types.AttributeValueMemberS{Value: entry.FileName.Raw}, string(TempPathAttr): &types.AttributeValueMemberS{Value: entry.TempPath.Raw}, string(CompleteAttr): &types.AttributeValueMemberS{Value: *aws.String(strconv.FormatBool(entry.Complete))}}
+	attributes := map[string]types.AttributeValue{string(TablePath): &types.AttributeValueMemberS{Value: entry.TablePath.Raw}, string(FileName): &types.AttributeValueMemberS{Value: entry.FileName.Raw}, string(TempPath): &types.AttributeValueMemberS{Value: entry.TempPath.Raw}, string(Complete): &types.AttributeValueMemberS{Value: *aws.String(strconv.FormatBool(entry.Complete))}}
 
 	if entry.ExpireTime != 0 {
-		attributes[string(ExpireTimeAttr)] = &types.AttributeValueMemberN{Value: *aws.String(fmt.Sprint(entry.ExpireTime))}
+		attributes[string(ExpireTime)] = &types.AttributeValueMemberN{Value: *aws.String(fmt.Sprint(entry.ExpireTime))}
 	}
 
 	pir := &dynamodb.PutItemInput{
@@ -301,7 +301,7 @@ func (ls *DynamoDBLogStore) createPutItemRequest(entry *logstore.CommitEntry, ov
 		Item:      attributes}
 
 	if !overwrite {
-		pir.ConditionExpression = aws.String(fmt.Sprintf("attribute_not_exists(%s)", string(FileNameAttr)))
+		pir.ConditionExpression = aws.String(fmt.Sprintf("attribute_not_exists(%s)", string(FileName)))
 	}
 
 	return pir, nil


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Use `Attribute` type for constants in `dynamodblogstore.go`.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
