### PR TITLE
Removed pointer on Add.Stats and Add.Tags

### DIFF
--- a/action.go
+++ b/action.go
@@ -57,9 +57,9 @@ type Add struct {
 	// that would not affect the final results.
 	DataChange bool `json:"dataChange" parquet:"name=dataChange, repetition=OPTIONAL"`
 	// Map containing metadata about this file
-	Tags *map[string]string `json:"tags,omitempty" parquet:"name=tags, repetition=OPTIONAL, keyconverted=UTF8, valueconverted=UTF8"`
+	Tags map[string]string `json:"tags,omitempty" parquet:"name=tags, repetition=OPTIONAL, keyconverted=UTF8, valueconverted=UTF8"`
 	// Contains statistics (e.g., count, min/max values for columns) about the data in this file
-	Stats *string `json:"stats" parquet:"name=stats, repetition=OPTIONAL, converted=UTF8"`
+	Stats string `json:"stats" parquet:"name=stats, repetition=OPTIONAL, converted=UTF8"`
 
 	// TODO - parsed fields dropped after the parquet library switch.
 	// This requires dropping writer version to 2.

--- a/action_test.go
+++ b/action_test.go
@@ -65,11 +65,11 @@ func TestLogEntryFromActions(t *testing.T) {
 		t.Errorf("want:\n%s\nhas:\n%s\n", expectedStr, string(logs))
 	}
 
-	if !strings.Contains(string(logs), `{"add":{"path":"part-1.snappy.parquet","partitionValues":null,"size":1,"modificationTime":1675020556534,"dataChange":false,"stats":null}}`) {
+	if !strings.Contains(string(logs), `{"add":{"path":"part-1.snappy.parquet","partitionValues":null,"size":1,"modificationTime":1675020556534,"dataChange":false,"stats":""}}`) {
 		t.Errorf("want:\n%s\nhas:\n%s\n", expectedStr, string(logs))
 	}
 
-	if !strings.Contains(string(logs), `{"path":"part-2.snappy.parquet","partitionValues":null,"size":2,"modificationTime":1675020556534,"dataChange":false,"stats":null}`) {
+	if !strings.Contains(string(logs), `{"path":"part-2.snappy.parquet","partitionValues":null,"size":2,"modificationTime":1675020556534,"dataChange":false,"stats":""}`) {
 		t.Errorf("want:\n%s\nhas:\n%s\n", expectedStr, string(logs))
 	}
 }
@@ -336,7 +336,7 @@ func TestActionFromLogEntry(t *testing.T) {
 	}{
 		{name: "Add", args: args{unstructuredResult: map[string]json.RawMessage{"add": []byte(`{"path":"mypath.parquet","size":8382,"partitionValues":{"date":"2021-03-09"},"modificationTime":1679610144893,"dataChange":true,"stats":"{\"numRecords\":155,\"tightBounds\":false,\"minValues\":{\"timestamp\":1615338375007003},\"maxValues\":{\"timestamp\":1615338377517216},\"nullCount\":null}"}`)}},
 			want: &Add{Path: "mypath.parquet", Size: 8382, PartitionValues: map[string]string{"date": "2021-03-09"}, ModificationTime: 1679610144893, DataChange: true,
-				Stats: &statsString}, wantErr: nil},
+				Stats: statsString}, wantErr: nil},
 		{name: "CommitInfo", args: args{unstructuredResult: map[string]json.RawMessage{"commitInfo": []byte(`{"clientVersion":"delta-go.alpha-0.0.0","isBlindAppend":true,"operation":"delta-go.Write","timestamp":1679610144893}`)}},
 			want: &CommitInfo{"clientVersion": "delta-go.alpha-0.0.0", "isBlindAppend": true, "operation": "delta-go.Write",
 				"timestamp": float64(1679610144893)}, wantErr: nil},
@@ -371,12 +371,11 @@ func TestActionsFromLogEntries(t *testing.T) {
 		NumRecords: 123,
 	}
 
-	statsString := string(stats.Json())
 	add := Add{
 		Path:             "part-1.snappy.parquet",
 		Size:             1,
 		ModificationTime: 1675020556534,
-		Stats:            &statsString,
+		Stats:            string(stats.Json()),
 	}
 
 	write := Write{Mode: ErrorIfExists}

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -209,7 +209,7 @@ func TestSimpleCheckpoint(t *testing.T) {
 			Size:             4567,
 			ModificationTime: 1627668694000,
 			DataChange:       false,
-			Stats:            &expectedStats,
+			Stats:            expectedStats,
 		}
 		if !reflect.DeepEqual(expectedAdd, checkAdd) {
 			t.Errorf("Add does not match: expected %v found %v", expectedAdd, checkAdd)

--- a/delta_test.go
+++ b/delta_test.go
@@ -131,13 +131,12 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	metadata := NewDeltaTableMetaData("Test Table", "", format, schema, []string{}, config)
 	protocol := new(Protocol).Default()
 	stats := Stats{NumRecords: 1, MinValues: map[string]any{"first_column": 1}}
-	statsString := string(stats.Json())
 	path := "part-123.snappy.parquet"
 	add := Add{
 		Path:             path,
 		Size:             984,
 		ModificationTime: time.Now().UnixMilli(),
-		Stats:            &statsString,
+		Stats:            string(stats.Json()),
 	}
 	commitInfo := make(map[string]any)
 	commitInfo["test"] = 123
@@ -184,7 +183,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 		t.Error("Add path not deserialized properly")
 	}
 	var s Stats
-	err = json.Unmarshal([]byte(*a.Stats), &s)
+	err = json.Unmarshal([]byte(a.Stats), &s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,13 +618,12 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 		t.Error(err)
 	}
 
-	statsString := string(stats.Json())
 	add := Add{
 		Path:             fileName,
 		Size:             p.Size,
 		DataChange:       true,
 		ModificationTime: time.Now().UnixMilli(),
-		Stats:            &statsString,
+		Stats:            string(stats.Json()),
 		PartitionValues:  make(map[string]string),
 	}
 
@@ -666,13 +664,12 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 				t.Error(err)
 			}
 
-			statsString := string(stats.Json())
 			add := Add{
 				Path:             fileName,
 				Size:             p.Size,
 				DataChange:       true,
 				ModificationTime: time.Now().UnixMilli(),
-				Stats:            &statsString,
+				Stats:            string(stats.Json()),
 				PartitionValues:  make(map[string]string),
 			}
 
@@ -730,13 +727,12 @@ func TestCreateWithParquet(t *testing.T) {
 		t.Error(err)
 	}
 
-	statsString := string(stats.Json())
 	add := Add{
 		Path:             fileName,
 		Size:             p.Size,
 		DataChange:       true,
 		ModificationTime: time.Now().UnixMilli(),
-		Stats:            &statsString,
+		Stats:            string(stats.Json()),
 		PartitionValues:  make(map[string]string),
 	}
 
@@ -1064,7 +1060,7 @@ func TestLoadVersion(t *testing.T) {
 	dataChange := true
 	add.DataChange = dataChange
 	stats := "{\"numRecords\":1,\"minValues\":{\"value\":\"x\",\"ts\":\"2021-07-30T18:11:24.594Z\"},\"maxValues\":{\"value\":\"x\",\"ts\":\"2021-07-30T18:11:24.594Z\"},\"nullCount\":{\"value\":0,\"ts\":0}}"
-	add.Stats = &stats
+	add.Stats = stats
 	expectedState.Files[add.Path] = *add
 	add = new(Add)
 	path2 := "date=2020-06-01/part-00000-762e2b03-6a04-4707-b676-5d38d1ef9fca.c000.snappy.parquet"
@@ -1075,7 +1071,7 @@ func TestLoadVersion(t *testing.T) {
 	add.ModificationTime = modificationTime2
 	add.DataChange = dataChange
 	stats2 := "{\"numRecords\":1,\"minValues\":{\"value\":\"x\",\"ts\":\"2021-07-30T18:11:27.001Z\"},\"maxValues\":{\"value\":\"x\",\"ts\":\"2021-07-30T18:11:27.001Z\"},\"nullCount\":{\"value\":0,\"ts\":0}}"
-	add.Stats = &stats2
+	add.Stats = stats2
 	expectedState.Files[add.Path] = *add
 	var schema SchemaTypeStruct = SchemaTypeStruct{
 		Fields: []SchemaField{


### PR DESCRIPTION
## Changes
Removed pointers in Add struct. Stats writes to commit.json as `"stats":""` now, before it wrote as `"stats":null`


## Tests
Ran unit tests.

Local testing:
`spark version 3.4.1`
`pyspark --packages io.delta:delta-core_2.12:2.4.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"`

Tested with local spark read and TestCreateWithParquet where the commit was set manually with the add record `{"add":{"path":"part-d35f4fec-c372-43d7-ad35-383d17404d9c.snappy.parquet","partitionValues":{},"size":1708,"modificationTime":1694730396674,"dataChange":true,"stats":""}}`

```
>>> df = spark.read.format("delta").load("/var/folders/5p/bvr9gvdd57b51vzkvk8j346h0000gn/T/TestCreateWithParquet4200968178/001")
>>> df.show()
+-------------------+--------------------+--------------------+-------------------+-------------------+--------------------+
|                 id|           timestamp|               label|             value1|             value2|                data|
+-------------------+--------------------+--------------------+-------------------+-------------------+--------------------+
|6653509509786596717|2023-09-14 15:26:...|ef29312b-2701-4b2...| 0.2224282173094445| 0.2224282173094445|[72 7B 3E F8 33 C...|
|6653509509786596717|2023-09-14 15:26:...|8fff74c5-cad8-497...| 0.5833953431433743|               null|[15 90 16 F7 BA 6...|
|6653509509786596717|2023-09-14 15:26:...|8853f41f-5988-4a0...|0.06352517142829617|0.06352517142829617|[1B 89 01 F0 2B 5...|
|6653509509786596717|2023-09-14 15:26:...|021b2dbc-786a-4a4...| 0.4342717107410492|               null|[42 F2 88 E4 F2 E...|
|6653509509786596717|2023-09-14 15:26:...|653fd435-2fbe-49a...| 0.1820681388538504|               null|[81 E9 50 F8 C1 4...|
+-------------------+--------------------+--------------------+-------------------+-------------------+--------------------+
>>> df.where("value2 > 0.09").show()
+-------------------+--------------------+--------------------+------------------+------------------+--------------------+
|                 id|           timestamp|               label|            value1|            value2|                data|
+-------------------+--------------------+--------------------+------------------+------------------+--------------------+
|6653509509786596717|2023-09-14 15:26:...|ef29312b-2701-4b2...|0.2224282173094445|0.2224282173094445|[72 7B 3E F8 33 C...|
+-------------------+--------------------+--------------------+------------------+------------------+--------------------+
```

- [x] `make test` passing
- [x] relevant integration tests passing
