### PR TITLE
Fix DeltaTable.Exists() - look for checkpoint files as well as commit files, and iterate the entire log folder

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,7 +53,7 @@ jobs:
         run: make test
 
       - name: Publish test coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
 
   fmt:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ dump.rdb
 
 .DS_Store
 .vscode
+coverage.txt


### PR DESCRIPTION
## Changes
- Change the `DeltaTable.Exists()` function to recognize checkpoint files as well as commit files
- Use the list iterator when looking for commit/checkpoint files, so that if none are on the first page of results we will look through the entire log folder
- Add a pagination option to the S3 mock client for testing
- Expand unit test

## Tests

I added a unit test specifically for this situation, `TestDeltaTableExistsManyTempFiles()`.  It fails without the changes to `Exists()` and passes with them.

- [X] `make test` passing
- [ ] relevant integration tests passing
