### PR TITLE
fix: prefix global error variables with "Err" instead of "Error"

### DIFF
--- a/action.go
+++ b/action.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	ErrorActionJSONFormat error = errors.New("invalid format for action JSON")
-	ErrorActionUnknown    error = errors.New("unknown action")
-	ErrorActionConversion error = errors.New("error reading action")
+	ErrActionJSONFormat error = errors.New("invalid format for action JSON")
+	ErrActionUnknown    error = errors.New("unknown action")
+	ErrActionConversion error = errors.New("error reading action")
 )
 
 // Delta log action that describes a parquet data file that is part of the table.
@@ -284,7 +284,7 @@ const (
 // / Retrieve an action from a log entry
 func actionFromLogEntry(unstructuredResult map[string]json.RawMessage) (Action, error) {
 	if len(unstructuredResult) != 1 {
-		return nil, errors.Join(ErrorActionJSONFormat, errors.New("log entry JSON must have one value"))
+		return nil, errors.Join(ErrActionJSONFormat, errors.New("log entry JSON must have one value"))
 	}
 
 	var action Action
@@ -308,12 +308,12 @@ func actionFromLogEntry(unstructuredResult map[string]json.RawMessage) (Action, 
 	} else if _, actionFound = unstructuredResult[string(CDCActionKey)]; actionFound {
 		return nil, ErrorCDCNotSupported
 	} else {
-		return nil, ErrorActionUnknown
+		return nil, ErrActionUnknown
 	}
 
 	err := json.Unmarshal(marshalledAction, action)
 	if err != nil {
-		return nil, errors.Join(ErrorActionJSONFormat, err)
+		return nil, errors.Join(ErrActionJSONFormat, err)
 	}
 
 	return action, nil
@@ -330,7 +330,7 @@ func ActionsFromLogEntries(logEntries []byte) ([]Action, error) {
 		var unstructuredResult map[string]json.RawMessage
 		err := json.Unmarshal(currentLine, &unstructuredResult)
 		if err != nil {
-			return nil, errors.Join(ErrorActionJSONFormat, err)
+			return nil, errors.Join(ErrActionJSONFormat, err)
 		}
 		action, err := actionFromLogEntry(unstructuredResult)
 		if err != nil {

--- a/action_test.go
+++ b/action_test.go
@@ -334,13 +334,13 @@ func TestActionFromLogEntry(t *testing.T) {
 		{name: "Protocol", args: args{unstructuredResult: map[string]json.RawMessage{"protocol": []byte(`{"minReaderVersion":2,"minWriterVersion":7}`)}},
 			want: &Protocol{MinReaderVersion: 2, MinWriterVersion: 7}, wantErr: nil},
 		{name: "Fail on invalid JSON", args: args{unstructuredResult: map[string]json.RawMessage{"add": []byte(`"path":"s3a://bucket/table","size":8382,"partitionValues":{"date":"2021-03-09"},"modificationTime":1679610144893,"dataChange":true}`)}},
-			want: nil, wantErr: ErrorActionJSONFormat},
-		{name: "Fail on unknown", args: args{unstructuredResult: map[string]json.RawMessage{"fake": []byte(`{}`)}}, want: nil, wantErr: ErrorActionUnknown},
+			want: nil, wantErr: ErrActionJSONFormat},
+		{name: "Fail on unknown", args: args{unstructuredResult: map[string]json.RawMessage{"fake": []byte(`{}`)}}, want: nil, wantErr: ErrActionUnknown},
 		{name: "Fail on CDC", args: args{unstructuredResult: map[string]json.RawMessage{"cdc": []byte(`{}`)}}, want: nil, wantErr: ErrorCDCNotSupported},
 		{name: "Fail on multiple entries", args: args{unstructuredResult: map[string]json.RawMessage{
 			"protocol":   []byte(`{"minReaderVersion":2,"minWriterVersion":7}`),
 			"commitInfo": []byte(`{"clientVersion":"delta-go.alpha-0.0.0","isBlindAppend":true,"operation":"delta-go.Write","timestamp":1679610144893}`)}},
-			want: nil, wantErr: ErrorActionJSONFormat},
+			want: nil, wantErr: ErrActionJSONFormat},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/arrow.go
+++ b/arrow.go
@@ -485,15 +485,15 @@ func appendGoValueToArrowBuilder(goValue reflect.Value, builder array.Builder, g
 	case arrow.FLOAT64:
 		builder.(*array.Float64Builder).Append(goValue.Float())
 	case arrow.INTERVAL_DAY_TIME:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_DAY_TIME"))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_DAY_TIME"))
 	case arrow.INTERVAL_MONTHS:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_MONTHS"))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_MONTHS"))
 	case arrow.INTERVAL_MONTH_DAY_NANO:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_MONTH_DAY_NANO"))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type INTERVAL_MONTH_DAY_NANO"))
 	case arrow.NULL:
 		builder.AppendNull()
 	case arrow.RUN_END_ENCODED:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type RUN_END_ENCODED"))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type RUN_END_ENCODED"))
 	case arrow.STRING:
 		builder.(*array.StringBuilder).Append(goValue.String())
 	case arrow.TIME32:
@@ -507,7 +507,7 @@ func appendGoValueToArrowBuilder(goValue reflect.Value, builder array.Builder, g
 		builder.(*array.TimestampBuilder).Append(arrow.Timestamp(goValue.Int()))
 	// Nested types
 	case arrow.DICTIONARY:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type DICTIONARY"))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, errors.New("unsupported arrow type DICTIONARY"))
 	case arrow.FIXED_SIZE_LIST:
 		listBuilder := builder.(*array.FixedSizeListBuilder)
 		if goValue.Len() == 0 {
@@ -571,7 +571,7 @@ func appendGoValueToArrowBuilder(goValue reflect.Value, builder array.Builder, g
 			// If not in the goNameArrowIndexMap, we don't want to try to append it
 		}
 	default:
-		return errors.Join(ErrorNotImplemented, ErrorGeneratingCheckpoint, fmt.Errorf("unsupported arrow type %s", builder.Type().Name()))
+		return errors.Join(ErrNotImplemented, ErrorGeneratingCheckpoint, fmt.Errorf("unsupported arrow type %s", builder.Type().Name()))
 	}
 	return nil
 }

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -232,7 +232,7 @@ func createCheckpointFor(tableState *DeltaTableState, store storage.ObjectStore,
 		}
 		checkpointPath := storage.PathFromIter([]string{"_delta_log", checkpointFileName})
 		_, err = store.Head(checkpointPath)
-		if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+		if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 			return ErrorCheckpointAlreadyExists
 		}
 		err = store.Put(checkpointPath, parquetBytes)
@@ -321,7 +321,7 @@ func flushDeleteFiles(store storage.ObjectStore, maybeToDelete []DeletionCandida
 func removeExpiredLogsAndCheckpoints(beforeVersion int64, maxTimestamp time.Time, store storage.ObjectStore) (int, error) {
 	if !store.IsListOrdered() {
 		// Currently all object stores return list results sorted
-		return 0, errors.Join(ErrorNotImplemented, errors.New("removing expired logs is not implemented for this object store"))
+		return 0, errors.Join(ErrNotImplemented, errors.New("removing expired logs is not implemented for this object store"))
 	}
 
 	candidatesForDeletion := make([]DeletionCandidate, 0, 200)
@@ -331,7 +331,7 @@ func removeExpiredLogsAndCheckpoints(beforeVersion int64, maxTimestamp time.Time
 	// First collect all the logs/checkpoints that might be eligible for deletion
 	for {
 		meta, err := logIterator.Next()
-		if errors.Is(err, storage.ErrorObjectDoesNotExist) {
+		if errors.Is(err, storage.ErrObjectDoesNotExist) {
 			break
 		}
 		isValid, version := CommitOrCheckpointVersionFromUri(meta.Location)

--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ import (
 type DeltaConfigKey string
 
 var (
-	ErrorConfigValidation = errors.New("error validating delta configuration")
+	ErrConfigValidation = errors.New("error validating delta configuration")
 )
 
 const (
@@ -54,7 +54,7 @@ func ParseInterval(input string) (time.Duration, error) {
 	input = strings.TrimPrefix(strings.ToLower(input), "interval ")
 	components := strings.Fields(input)
 	if len(components) == 0 || len(components)%2 != 0 {
-		return time.Duration(0), ErrorConfigValidation
+		return time.Duration(0), ErrConfigValidation
 	}
 	i := 0
 	var totalDuration time.Duration
@@ -64,7 +64,7 @@ func ParseInterval(input string) (time.Duration, error) {
 		numericComponent, err := strconv.ParseInt(numericComponentStr, 10, 64)
 		durationComponent := time.Duration(numericComponent)
 		if err != nil {
-			return time.Duration(0), errors.Join(ErrorConfigValidation, err)
+			return time.Duration(0), errors.Join(ErrConfigValidation, err)
 		}
 		i++
 		unit := components[i]
@@ -95,7 +95,7 @@ func ParseInterval(input string) (time.Duration, error) {
 		case "year", "years":
 			durationUnit = time.Hour * 24 * 7 * 365
 		default:
-			return time.Duration(0), ErrorConfigValidation
+			return time.Duration(0), ErrConfigValidation
 		}
 		totalDuration += (durationUnit * durationComponent)
 	}

--- a/delta_test.go
+++ b/delta_test.go
@@ -215,7 +215,7 @@ func TestDeltaTableTryCommitTransaction(t *testing.T) {
 
 	//try again with the same version
 	err = transaction.TryCommit(&commit)
-	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Error(err)
 	}
 	if transaction.DeltaTable.State.Version != 2 {
@@ -254,7 +254,7 @@ func TestTryCommitWithExistingLock(t *testing.T) {
 
 	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{MaxRetryCommitAttempts: 3})
 	version, err := transaction.Commit(operation, appMetaData)
-	if !errors.Is(err, ErrorExceededCommitRetryAttempts) {
+	if !errors.Is(err, ErrExceededCommitRetryAttempts) {
 		t.Error(err)
 	}
 	if version != -1 {
@@ -289,7 +289,7 @@ type testBrokenUnlockLocker struct {
 }
 
 func (l *testBrokenUnlockLocker) Unlock() error {
-	return lock.ErrorUnableToUnlock
+	return lock.ErrUnableToUnlock
 }
 
 func TestCommitUnlockFailure(t *testing.T) {
@@ -308,7 +308,7 @@ func TestCommitUnlockFailure(t *testing.T) {
 
 	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{MaxRetryCommitAttempts: 3})
 	_, err := transaction.Commit(operation, appMetaData)
-	if !errors.Is(err, lock.ErrorUnableToUnlock) {
+	if !errors.Is(err, lock.ErrUnableToUnlock) {
 		t.Error(err)
 	}
 }
@@ -1166,7 +1166,7 @@ func TestLoadVersion(t *testing.T) {
 	// Invalid version should return error
 	version = 20
 	err = table.LoadVersion(&version)
-	if !errors.Is(err, ErrorInvalidVersion) {
+	if !errors.Is(err, ErrInvalidVersion) {
 		t.Error("loading an invalid version did not return correct error")
 	}
 

--- a/internal/dynamodbutils/dynamodbclient.go
+++ b/internal/dynamodbutils/dynamodbclient.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	ErrorExceededTableCreateRetryAttempts error = errors.New("failed to create table")
+	ErrExceededTableCreateRetryAttempts error = errors.New("failed to create table")
 )
 
 // Defines methods implemented by dynamodb.Client
@@ -45,7 +45,7 @@ func TryEnsureDynamoDBTableExists(client DynamoDBClient, tableName string, creat
 	for {
 		if attemptNumber >= int(maxRetryTableCreateAttempts) {
 			log.Debugf("delta-go: Table create attempt failed. Attempts exhausted beyond maxRetryDynamoDbTableCreateAttempts of %d so failing.", maxRetryTableCreateAttempts)
-			return ErrorExceededTableCreateRetryAttempts
+			return ErrExceededTableCreateRetryAttempts
 		}
 
 		status := "CREATING"

--- a/internal/s3utils/s3mock.go
+++ b/internal/s3utils/s3mock.go
@@ -270,7 +270,7 @@ func (m *MockS3Client) FileExists(baseURI storage.Path, location storage.Path) (
 		return false, err
 	}
 	_, err = m.fileStore.Head(filePath)
-	if errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if errors.Is(err, storage.ErrObjectDoesNotExist) {
 		return false, nil
 	}
 	if err != nil {

--- a/lock/dynamolock/dynamolock.go
+++ b/lock/dynamolock/dynamolock.go
@@ -131,7 +131,7 @@ func (l *DynamoLock) TryLock() (bool, error) {
 	lItem, err := l.lockClient.AcquireLock(l.key)
 	l.lockedItem = lItem
 	if err != nil {
-		return false, errors.Join(lock.ErrorLockNotObtained, err)
+		return false, errors.Join(lock.ErrLockNotObtained, err)
 	}
 	return true, nil
 }
@@ -140,11 +140,11 @@ func (l *DynamoLock) TryLock() (bool, error) {
 func (l *DynamoLock) Unlock() error {
 	success, err := l.lockClient.ReleaseLock(l.lockedItem, dynamolock.WithDeleteLock(l.opts.DeleteOnRelease))
 	if !success {
-		return lock.ErrorUnableToUnlock
+		return lock.ErrUnableToUnlock
 	}
 	l.lockClient.Close()
 	if err != nil {
-		return errors.Join(lock.ErrorUnableToUnlock, err)
+		return errors.Join(lock.ErrUnableToUnlock, err)
 	}
 	return nil
 }

--- a/lock/filelock/filelock.go
+++ b/lock/filelock/filelock.go
@@ -100,7 +100,7 @@ func (l *FileLock) TryLock() (bool, error) {
 	}
 
 	if err != nil || !locked {
-		return locked, errors.Join(lock.ErrorLockNotObtained, err)
+		return locked, errors.Join(lock.ErrLockNotObtained, err)
 	}
 	return locked, err
 }
@@ -109,7 +109,7 @@ func (l *FileLock) TryLock() (bool, error) {
 func (l *FileLock) Unlock() error {
 	err := l.lock.Unlock()
 	if err != nil {
-		return errors.Join(lock.ErrorUnableToUnlock, err)
+		return errors.Join(lock.ErrUnableToUnlock, err)
 	}
 
 	if l.opts.DeleteOnRelease {

--- a/lock/filelock/filelock_test.go
+++ b/lock/filelock/filelock_test.go
@@ -38,8 +38,8 @@ func TestTryLock(t *testing.T) {
 
 	otherFileLock := FileLock{baseURI: tmpPath, key: "_commit.lock"}
 	hasLock, err := otherFileLock.TryLock()
-	if !errors.Is(err, lock.ErrorLockNotObtained) {
-		t.Errorf("err = %e; expected %e", err, lock.ErrorLockNotObtained)
+	if !errors.Is(err, lock.ErrLockNotObtained) {
+		t.Errorf("err = %e; expected %e", err, lock.ErrLockNotObtained)
 	}
 	if hasLock {
 		t.Errorf("hasLock = %v; want false", hasLock)
@@ -79,8 +79,8 @@ func TestNewLock(t *testing.T) {
 
 	otherFileLock := FileLock{baseURI: tmpPath, key: "_new_commit.lock"}
 	hasLock, err := otherFileLock.TryLock()
-	if !errors.Is(err, lock.ErrorLockNotObtained) {
-		t.Errorf("err = %e; expected %e", err, lock.ErrorLockNotObtained)
+	if !errors.Is(err, lock.ErrLockNotObtained) {
+		t.Errorf("err = %e; expected %e", err, lock.ErrLockNotObtained)
 	}
 	if hasLock {
 		t.Errorf("hasLock = %v; want false", hasLock)

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	ErrorLockNotObtained error = errors.New("the lock could not be obtained")
-	ErrorUnableToUnlock  error = errors.New("the lock could not be released")
+	ErrLockNotObtained error = errors.New("the lock could not be obtained")
+	ErrUnableToUnlock  error = errors.New("the lock could not be released")
 )
 
 // Locker is the abstract interface for providing a lock client that stores data in the lock

--- a/lock/redislock/redislock.go
+++ b/lock/redislock/redislock.go
@@ -95,7 +95,7 @@ func (l *RedisLock) TryLock() (bool, error) {
 	// Obtain a lock for our given mutex. After this is successful, no one else
 	// can obtain the same lock (the same mutex name) until we unlock it.
 	if err := l.redsyncMutex.Lock(); err != nil {
-		return false, errors.Join(lock.ErrorLockNotObtained, err)
+		return false, errors.Join(lock.ErrLockNotObtained, err)
 	}
 
 	return true, nil
@@ -105,7 +105,7 @@ func (l *RedisLock) TryLock() (bool, error) {
 func (l *RedisLock) Unlock() error {
 	// Release the lock so other processes or threads can obtain a lock.
 	if ok, err := l.redsyncMutex.Unlock(); !ok || err != nil {
-		return errors.Join(lock.ErrorUnableToUnlock, err)
+		return errors.Join(lock.ErrUnableToUnlock, err)
 	}
 
 	return nil

--- a/storage/filestore/filestore_test.go
+++ b/storage/filestore/filestore_test.go
@@ -63,7 +63,7 @@ func TestHead(t *testing.T) {
 	//check before writing the file
 	meta, err := store.Head(putPath)
 	//err object should not exist
-	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("err = %e;", err)
 	}
 
@@ -110,7 +110,7 @@ func TestRenameIfNotExists(t *testing.T) {
 
 	//File already exists from previous rename, so err should be storage.ErrorVersionAlreadyExists
 	err = store.RenameIfNotExists(fromPath, toPath)
-	if !errors.Is(err, storage.ErrorObjectAlreadyExists) {
+	if !errors.Is(err, storage.ErrObjectAlreadyExists) {
 		t.Errorf("err = %e;", err)
 	}
 
@@ -156,7 +156,7 @@ func TestDelete(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error calling Delete on a non-existent file")
 	}
-	if !errors.Is(err, storage.ErrorDeleteObject) && !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrDeleteObject) && !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Invalid error from Delete: %e", err)
 	}
 }

--- a/storage/s3store/s3store_test.go
+++ b/storage/s3store/s3store_test.go
@@ -97,7 +97,7 @@ func TestPutErrorHandling(t *testing.T) {
 	data := []byte("data1")
 	mockClient.MockError = errors.New("Something went wrong")
 	err := s3Store.Put(path, data)
-	if !errors.Is(err, storage.ErrorPutObject) {
+	if !errors.Is(err, storage.ErrPutObject) {
 		t.Errorf("Expected error calling Put")
 	}
 }
@@ -128,7 +128,7 @@ func TestGetErrorHandling(t *testing.T) {
 	// Test calling Get on a nonexistent file returns an error
 	path := storage.NewPath("test.txt")
 	_, err := s3Store.Get(path)
-	if !errors.Is(err, storage.ErrorGetObject) && !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrGetObject) && !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Calling Get on a nonexistent file did not return an appropriate error")
 	}
 
@@ -141,7 +141,7 @@ func TestGetErrorHandling(t *testing.T) {
 	}
 	mockClient.MockError = errors.New("Something went wrong")
 	_, err = s3Store.Get(path)
-	if !errors.Is(err, storage.ErrorGetObject) {
+	if !errors.Is(err, storage.ErrGetObject) {
 		t.Errorf("Calling Get did not return an appropriate error")
 	}
 
@@ -156,7 +156,7 @@ func TestGetErrorHandling(t *testing.T) {
 	responseError.ResponseError = smithyResponseError
 	mockClient.MockError = responseError
 	_, err = s3Store.Get(path)
-	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Head did not return an appropriate error")
 	}
 }
@@ -212,7 +212,7 @@ func TestRenameErrorHandling(t *testing.T) {
 	// Test rename where source does not exist
 	newPath := storage.NewPath("second_copy.txt")
 	err := s3Store.Rename(path, newPath)
-	if !errors.Is(err, storage.ErrorCopyObject) && !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrCopyObject) && !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Rename did not return an appropriate error")
 	}
 
@@ -226,7 +226,7 @@ func TestRenameErrorHandling(t *testing.T) {
 	// Test rename where client returns an error
 	mockClient.MockError = errors.New("Something went wrong")
 	err = s3Store.Rename(path, newPath)
-	if !errors.Is(err, storage.ErrorCopyObject) && !errors.Is(err, storage.ErrorDeleteObject) {
+	if !errors.Is(err, storage.ErrCopyObject) && !errors.Is(err, storage.ErrDeleteObject) {
 		t.Errorf("Rename did not return an appropriate error")
 	}
 }
@@ -277,7 +277,7 @@ func TestRenameIfNotExistsErrorHandling(t *testing.T) {
 
 	// Renaming and overwriting should return an error
 	err = s3Store.RenameIfNotExists(path, overwritePath)
-	if !errors.Is(err, storage.ErrorObjectAlreadyExists) {
+	if !errors.Is(err, storage.ErrObjectAlreadyExists) {
 		t.Errorf("RenameIfNotExists did not return expected error when overwriting")
 	}
 
@@ -285,7 +285,7 @@ func TestRenameIfNotExistsErrorHandling(t *testing.T) {
 	mockClient.MockError = errors.New("Something went wrong")
 	newPath := storage.NewPath("third_copy.txt")
 	err = s3Store.Rename(path, newPath)
-	if !errors.Is(err, storage.ErrorCopyObject) && !errors.Is(err, storage.ErrorDeleteObject) {
+	if !errors.Is(err, storage.ErrCopyObject) && !errors.Is(err, storage.ErrDeleteObject) {
 		t.Errorf("Rename did not return an error")
 	}
 }
@@ -327,7 +327,7 @@ func TestHeadErrorHandling(t *testing.T) {
 
 	// Test calling Head() on a nonexistent file
 	_, err := s3Store.Head(path)
-	if !errors.Is(err, storage.ErrorHeadObject) && !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrHeadObject) && !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Head did not return an expected error for nonexistent file")
 	}
 
@@ -339,7 +339,7 @@ func TestHeadErrorHandling(t *testing.T) {
 	}
 	mockClient.MockError = errors.New("Something went wrong")
 	_, err = s3Store.Head(path)
-	if !errors.Is(err, storage.ErrorHeadObject) {
+	if !errors.Is(err, storage.ErrHeadObject) {
 		t.Errorf("Head did not return an appropriate error")
 	}
 
@@ -354,7 +354,7 @@ func TestHeadErrorHandling(t *testing.T) {
 	responseError.ResponseError = smithyResponseError
 	mockClient.MockError = responseError
 	_, err = s3Store.Head(path)
-	if !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Head did not return an appropriate error")
 	}
 }
@@ -391,7 +391,7 @@ func TestDeleteErrorHandling(t *testing.T) {
 	// Test deleting a nonexistent file
 	path := storage.NewPath("first_copy.txt")
 	err := s3Store.Delete(path)
-	if !errors.Is(err, storage.ErrorDeleteObject) && !errors.Is(err, storage.ErrorObjectDoesNotExist) {
+	if !errors.Is(err, storage.ErrDeleteObject) && !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Errorf("Delete did not return an expected error for nonexistent file")
 	}
 
@@ -403,7 +403,7 @@ func TestDeleteErrorHandling(t *testing.T) {
 	}
 	mockClient.MockError = errors.New("Something went wrong")
 	err = s3Store.Delete(path)
-	if !errors.Is(err, storage.ErrorDeleteObject) {
+	if !errors.Is(err, storage.ErrDeleteObject) {
 		t.Errorf("Delete did not return an expected error")
 	}
 }
@@ -561,11 +561,11 @@ func TestListErrorHandling(t *testing.T) {
 	mockClient.MockError = errors.New("Something went wrong")
 	path := storage.NewPath("data.txt")
 	_, err := store.List(path, nil)
-	if !errors.Is(err, storage.ErrorListObjects) {
+	if !errors.Is(err, storage.ErrListObjects) {
 		t.Errorf("Delete did not return an expected error")
 	}
 	_, err = store.ListAll(path)
-	if !errors.Is(err, storage.ErrorListObjects) {
+	if !errors.Is(err, storage.ErrListObjects) {
 		t.Errorf("Delete did not return an expected error")
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -22,16 +22,16 @@ import (
 )
 
 var (
-	ErrorObjectAlreadyExists error = errors.New("the object already exists")
-	ErrorObjectDoesNotExist  error = errors.New("the object does not exist")
-	ErrorObjectIsDir         error = errors.New("the object is a directory")
-	ErrorCopyObject          error = errors.New("error while copying the object")
-	ErrorPutObject           error = errors.New("error while putting the object")
-	ErrorGetObject           error = errors.New("error while getting the object")
-	ErrorHeadObject          error = errors.New("error while getting the object head")
-	ErrorDeleteObject        error = errors.New("error while deleting the object")
-	ErrorURLJoinPath         error = errors.New("error during url.JoinPath")
-	ErrorListObjects         error = errors.New("error while listing objects")
+	ErrObjectAlreadyExists error = errors.New("the object already exists")
+	ErrObjectDoesNotExist  error = errors.New("the object does not exist")
+	ErrObjectIsDir         error = errors.New("the object is a directory")
+	ErrCopyObject          error = errors.New("error while copying the object")
+	ErrPutObject           error = errors.New("error while putting the object")
+	ErrGetObject           error = errors.New("error while getting the object")
+	ErrHeadObject          error = errors.New("error while getting the object head")
+	ErrDeleteObject        error = errors.New("error while deleting the object")
+	ErrURLJoinPath         error = errors.New("error during url.JoinPath")
+	ErrListObjects         error = errors.New("error while listing objects")
 )
 
 type DeltaStorageResult struct {
@@ -262,7 +262,7 @@ func (listIterator *ListIterator) Next() (*ObjectMeta, error) {
 	}
 
 	if listIterator.nextIndex >= len(listIterator.listResult.Objects) {
-		return nil, ErrorObjectDoesNotExist
+		return nil, ErrObjectDoesNotExist
 	}
 
 	result := listIterator.listResult.Objects[listIterator.nextIndex]

--- a/tablestate.go
+++ b/tablestate.go
@@ -152,7 +152,7 @@ func (tableState *DeltaTableState) processAction(actionInterface Action) error {
 	case *Cdc:
 		return ErrorCDCNotSupported
 	default:
-		return errors.Join(ErrorActionUnknown, fmt.Errorf("unknown %v", action))
+		return errors.Join(ErrActionUnknown, fmt.Errorf("unknown %v", action))
 	}
 	return nil
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Prefixes global error variables with "Err" instead of "Error." Both [Google](https://google.github.io/styleguide/go/best-practices#error-structure) and [Uber's](https://google.github.io/styleguide/go/best-practices#error-structure) style guides prefer this naming convention.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
