### PR TITLE
ci: use golangci-lint for linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,55 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: v1.54
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          #
+          # Note: By default, the `.golangci.yml` file should be at the root of the repository.
+          # The location of the configuration file can be changed by using `--config=`
+          # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true, then all caching functionality will be completely disabled,
+          #           takes precedence over all other caching options.
+          # skip-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true, then the action won't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true
+
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          # install-mode: "goinstall"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goVersion: [1.20.x]
+        goVersion: [1.21.x]
         redis:
           - '6.x'
 
@@ -43,9 +43,6 @@ jobs:
       - name: Pull external libraries
         run: make vendor
 
-      - name: Run linter
-        run: make lint
-
       - name: Run tests
         run: make test
 
@@ -64,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
           # No need to download cached dependencies when running gofmt.
           cache: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+# Refer to golangci-lint's example config file for more options and information:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+
+linters:
+  enable:
+    - errcheck
+    - goimports
+    - golint
+    - govet
+    - staticcheck
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,11 @@ fmt:
 	@gofmt -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 lint: vendor
-	@echo "✓ Linting source code with https://staticcheck.io/ ..."
-	@go run honnef.co/go/tools/cmd/staticcheck@v0.4.0 ./...
+	@echo "✓ Linting source code with https://golangci-lint.run/ ..."
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@golangci-lint run
 
-test: lint
+test:
 	@echo "✓ Running tests ..."
 	@go run gotest.tools/gotestsum@latest --format pkgname-and-test-fails \
 		--no-summary=skipped --raw-command go test -v \

--- a/action_test.go
+++ b/action_test.go
@@ -120,7 +120,7 @@ func TestLogEntryFromActionChangeMetaData(t *testing.T) {
 	id, _ := uuid.Parse("af23c9d7-fff1-4a5a-a2c8-55c59bd782aa")
 	schemaString := "..."
 	action := MetaData{
-		Id:               id,
+		ID:               id,
 		Format:           format,
 		SchemaString:     schemaString,
 		PartitionColumns: []string{},
@@ -287,7 +287,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 		Path:             "part-1.snappy.parquet",
 		Size:             1,
 		ModificationTime: 1675020556534,
-		Stats:            string(stats.Json()),
+		Stats:            string(stats.JSON()),
 	}
 
 	write := Write{Mode: ErrorIfExists}

--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package delta contains the resources required to interact with a Delta table.
 package delta
 
 import (
@@ -19,33 +21,55 @@ import (
 	"time"
 )
 
-type DeltaConfigKey string
+// ConfigKey represents a Delta configuration.
+type ConfigKey string
 
 var (
+	//ErrConfigValidation is returned when a Delta configuration cannot be validated.
 	ErrConfigValidation = errors.New("error validating delta configuration")
 )
 
 const (
-	AppendOnlyDeltaConfigKey                      DeltaConfigKey = "delta.appendOnly"
-	CheckpointIntervalDeltaConfigKey              DeltaConfigKey = "delta.checkpointInterval"
-	AutoOptimizeAutoCompactDeltaConfigKey         DeltaConfigKey = "delta.autoOptimize.autoCompact"
-	AutoOptimizeOptimizeWriteDeltaConfigKey       DeltaConfigKey = "delta.autoOptimize.optimizeWrite"
-	CheckpointWriteStatsAsJsonDeltaConfigKey      DeltaConfigKey = "delta.checkpoint.writeStatsAsJson"
-	CheckpointWriteStatsAsStructDeltaConfigKey    DeltaConfigKey = "delta.checkpoint.writeStatsAsStruct"
-	ColumnMappingModeDeltaConfigKey               DeltaConfigKey = "delta.columnMapping.mode"
-	DataSkippingNumIndexedColsDeltaConfigKey      DeltaConfigKey = "delta.dataSkippingNumIndexedCols"
-	DeletedFileRetentionDurationDeltaConfigKey    DeltaConfigKey = "delta.deletedFileRetentionDuration"
-	EnableChangeDataFeedDeltaConfigKey            DeltaConfigKey = "delta.enableChangeDataFeed"
-	IsolationLevelDeltaConfigKey                  DeltaConfigKey = "delta.isolationLevel"
-	LogRetentionDurationDeltaConfigKey            DeltaConfigKey = "delta.logRetentionDuration"
-	EnableExpiredLogCleanupDeltaConfigKey         DeltaConfigKey = "delta.enableExpiredLogCleanup"
-	MinReaderVersionDeltaConfigKey                DeltaConfigKey = "delta.minReaderVersion"
-	MinWriterVersionDeltaConfigKey                DeltaConfigKey = "delta.minWriterVersion"
-	RandomizeFilePrefixesDeltaConfigKey           DeltaConfigKey = "delta.randomizeFilePrefixes"
-	RandomPrefixLengthDeltaConfigKey              DeltaConfigKey = "delta.randomPrefixLength"
-	SetTransactionRetentionDurationDeltaConfigKey DeltaConfigKey = "delta.setTransactionRetentionDuration"
-	TargetFileSizeDeltaConfigKey                  DeltaConfigKey = "delta.targetFileSize"
-	TuneFileSizesForRewritesDeltaConfigKey        DeltaConfigKey = "delta.tuneFileSizesForRewrites"
+	// AppendOnlyDeltaConfigKey represents the Delta configuration to specify whethere a table is append-only.
+	AppendOnlyDeltaConfigKey ConfigKey = "delta.appendOnly"
+	// CheckpointIntervalDeltaConfigKey represents the Delta configuration to specify a checkpoint interval.
+	CheckpointIntervalDeltaConfigKey ConfigKey = "delta.checkpointInterval"
+	// AutoOptimizeAutoCompactDeltaConfigKey represents the Delta configuration to specify whether auto compaction needs to be enabled.
+	AutoOptimizeAutoCompactDeltaConfigKey ConfigKey = "delta.autoOptimize.autoCompact"
+	// AutoOptimizeOptimizeWriteDeltaConfigKey represents the Delta configuration to specify whether optimized writing needs to be enabled.
+	AutoOptimizeOptimizeWriteDeltaConfigKey ConfigKey = "delta.autoOptimize.optimizeWrite"
+	// CheckpointWriteStatsAsJSONDeltaConfigKey represents the Delta configuration to specify whether stats need to be written as a JSON object in a checkpoint.
+	CheckpointWriteStatsAsJSONDeltaConfigKey ConfigKey = "delta.checkpoint.writeStatsAsJson"
+	// CheckpointWriteStatsAsStructDeltaConfigKey represents the Delta configuration to specify whether stats need to be written as a struct in a checkpoint.
+	CheckpointWriteStatsAsStructDeltaConfigKey ConfigKey = "delta.checkpoint.writeStatsAsStruct"
+	// ColumnMappingModeDeltaConfigKey represents the Delta configuration to specify whether column mapping needs to be enabled.
+	ColumnMappingModeDeltaConfigKey ConfigKey = "delta.columnMapping.mode"
+	// DataSkippingNumIndexedColsDeltaConfigKey represents the Delta configuration to specify the number of columns for which to collect stats.
+	DataSkippingNumIndexedColsDeltaConfigKey ConfigKey = "delta.dataSkippingNumIndexedCols"
+	// DeletedFileRetentionDurationDeltaConfigKey represents the Delta configuration to specify the retention duration of a deleted file.
+	DeletedFileRetentionDurationDeltaConfigKey ConfigKey = "delta.deletedFileRetentionDuration"
+	// EnableChangeDataFeedDeltaConfigKey represents the Delta configuration to specify whether change data feed needs to be enabled.
+	EnableChangeDataFeedDeltaConfigKey ConfigKey = "delta.enableChangeDataFeed"
+	// IsolationLevelDeltaConfigKey represents the Delta configuration to specify what isolation level to use.
+	IsolationLevelDeltaConfigKey ConfigKey = "delta.isolationLevel"
+	// LogRetentionDurationDeltaConfigKey represents the Delta configuration to specify the retention duration of commit logs.
+	LogRetentionDurationDeltaConfigKey ConfigKey = "delta.logRetentionDuration"
+	// EnableExpiredLogCleanupDeltaConfigKey represents the Delta configuration to specify whether expired commit logs need be cleaned up.
+	EnableExpiredLogCleanupDeltaConfigKey ConfigKey = "delta.enableExpiredLogCleanup"
+	// MinReaderVersionDeltaConfigKey represents the Delta configuration tp specify the minimum reader version.
+	MinReaderVersionDeltaConfigKey ConfigKey = "delta.minReaderVersion"
+	// MinWriterVersionDeltaConfigKey represents the Delta configuration to specify the minimum writer version.
+	MinWriterVersionDeltaConfigKey ConfigKey = "delta.minWriterVersion"
+	// RandomizeFilePrefixesDeltaConfigKey represents the Delta configuration to specify whether file prefixes should be randomized.
+	RandomizeFilePrefixesDeltaConfigKey ConfigKey = "delta.randomizeFilePrefixes"
+	// RandomPrefixLengthDeltaConfigKey represents the Delta configuration to specify the number of characters generated for random prefixes.
+	RandomPrefixLengthDeltaConfigKey ConfigKey = "delta.randomPrefixLength"
+	// SetTransactionRetentionDurationDeltaConfigKey represents the Delta configuration to specify the retention duration of a transaction.
+	SetTransactionRetentionDurationDeltaConfigKey ConfigKey = "delta.setTransactionRetentionDuration"
+	// TargetFileSizeDeltaConfigKey represents the Delta configuration to specify the target size of a file.
+	TargetFileSizeDeltaConfigKey ConfigKey = "delta.targetFileSize"
+	// TuneFileSizesForRewritesDeltaConfigKey represents the Delta configuration to specify whether file sizes need to be tuned for rewrites.
+	TuneFileSizesForRewritesDeltaConfigKey ConfigKey = "delta.tuneFileSizesForRewrites"
 )
 
 // See safeStringToInterval at

--- a/examples/concurrent/main.go
+++ b/examples/concurrent/main.go
@@ -54,7 +54,7 @@ func main() {
 		Size:             p.Size,
 		DataChange:       true,
 		ModificationTime: time.Now().UnixMilli(),
-		Stats:            string(stats.Json()),
+		Stats:            string(stats.JSON()),
 		PartitionValues:  make(map[string]string),
 	}
 
@@ -98,7 +98,7 @@ func main() {
 				Size:             p.Size,
 				DataChange:       true,
 				ModificationTime: time.Now().UnixMilli(),
-				Stats:            string(stats.Json()),
+				Stats:            string(stats.JSON()),
 				PartitionValues:  make(map[string]string),
 			}
 

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -54,7 +54,7 @@ func main() {
 		Size:             p.Size,
 		DataChange:       true,
 		ModificationTime: time.Now().UnixMilli(),
-		Stats:            string(stats.Json()),
+		Stats:            string(stats.JSON()),
 		PartitionValues:  make(map[string]string),
 	}
 	transaction := table.CreateTransaction(delta.NewTransactionOptions())

--- a/internal/dynamodbutils/dynamodbclient.go
+++ b/internal/dynamodbutils/dynamodbclient.go
@@ -10,16 +10,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package dynamodbutils implements utilities used to interact with DynamoDB.
 package dynamodbutils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrFailedToCreateTable is returned when a table cannot be created if it does not exist.
+	ErrFailedToCreateTable = errors.New("failed to create DynamoDB table if it does not exist")
 )
 
 // Client defines methods implemented by AWS SDK for Go v2's DynamoDB client.

--- a/internal/dynamodbutils/dynamodbmock.go
+++ b/internal/dynamodbutils/dynamodbmock.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package dynamodbutils implements utilities used to interact with DynamoDB.
 package dynamodbutils
 
 import (

--- a/internal/s3utils/s3client.go
+++ b/internal/s3utils/s3client.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package s3utils implements utilities used to interact with S3.
 package s3utils
 
 import (

--- a/lock/dynamolock/dynamolock_test.go
+++ b/lock/dynamolock/dynamolock_test.go
@@ -27,19 +27,18 @@ func TestLock(t *testing.T) {
 	}
 	l, err := New(client, "delta_lock_table", "_commit.lock", options)
 	if err != nil {
-		t.Error("Failed to create lock")
+		t.Errorf("Failed to create lock: %v", err)
 	}
 
 	haslock, err := l.TryLock()
 	if err != nil {
-		t.Error("Failed to acquire lock")
+		t.Errorf("Failed to acquire lock: %v", err)
 	}
 	if haslock {
 		t.Log("Acquired lock")
 	}
 
-	err = l.Unlock()
-	if err != nil {
+	if err = l.Unlock(); err != nil {
 		t.Error(err)
 	}
 }
@@ -51,7 +50,7 @@ func TestNewLock(t *testing.T) {
 	}
 	l, err := New(client, "delta_lock_table", "_commit.lock", options)
 	if err != nil {
-		t.Error("Failed to create lock")
+		t.Errorf("Failed to create lock: %v", err)
 	}
 	nl, err := l.NewLock("_new_commit.lock")
 	if err != nil {
@@ -64,7 +63,7 @@ func TestNewLock(t *testing.T) {
 
 	haslock, err := nl.TryLock()
 	if err != nil {
-		t.Error("Failed to acquire lock")
+		t.Errorf("Failed to acquire lock: %v", err)
 	}
 	if haslock {
 		t.Log("Acquired lock")
@@ -105,7 +104,9 @@ func TestDeleteOnRelease(t *testing.T) {
 		t.Log("Acquired lock")
 	}
 
-	l.Unlock()
+	if err := l.Unlock(); err != nil {
+		t.Errorf("Failed to unlock: %v", err)
+	}
 
 	isExpired := l.lockedItem.IsExpired()
 	if !isExpired {
@@ -137,7 +138,9 @@ func TestDeleteOnRelease(t *testing.T) {
 		t.Log("Acquired lock")
 	}
 
-	l.Unlock()
+	if err := l.Unlock(); err != nil {
+		t.Errorf("Failed to unlock: %v", err)
+	}
 
 	isExpired = l.lockedItem.IsExpired()
 	if !isExpired {

--- a/lock/filelock/filelock_test.go
+++ b/lock/filelock/filelock_test.go
@@ -45,7 +45,10 @@ func TestTryLock(t *testing.T) {
 		t.Errorf("hasLock = %v; want false", hasLock)
 	}
 
-	l.Unlock()
+	if err := l.Unlock(); err != nil {
+		t.Errorf("Failed to release lock: %v", err)
+	}
+
 	hasLock, err = otherFileLock.TryLock()
 	if err != nil {
 		t.Errorf("err = %e;", err)
@@ -86,7 +89,10 @@ func TestNewLock(t *testing.T) {
 		t.Errorf("hasLock = %v; want false", hasLock)
 	}
 
-	nl.(*FileLock).Unlock()
+	if err := nl.(*FileLock).Unlock(); err != nil {
+		t.Errorf("Failed to release lock: %v", err)
+	}
+
 	hasLock, err = otherFileLock.TryLock()
 	if err != nil {
 		t.Errorf("err = %e;", err)
@@ -119,7 +125,10 @@ func TestTryLockBlocking(t *testing.T) {
 		t.Errorf("hasLock = %v; want true", hasLock)
 	}
 
-	l.Unlock()
+	if err := l.Unlock(); err != nil {
+		t.Errorf("Failed to release lock: %v", err)
+	}
+
 	hasLock, err = otherFileLock.TryLock()
 	if err != nil {
 		t.Errorf("err = %e;", err)
@@ -143,7 +152,9 @@ func TestDeleteOnRelease(t *testing.T) {
 		t.Errorf("locked = %v; want true", locked)
 	}
 
-	l.Unlock()
+	if err := l.Unlock(); err != nil {
+		t.Errorf("Failed to release lock: %v", err)
+	}
 
 	_, err = os.Stat(l.lock.Path())
 	if err != nil {
@@ -160,7 +171,9 @@ func TestDeleteOnRelease(t *testing.T) {
 		t.Errorf("locked = %v; want true", locked)
 	}
 
-	otherFileLock.Unlock()
+	if err := otherFileLock.Unlock(); err != nil {
+		t.Errorf("Failed to release lock: %v", err)
+	}
 
 	_, err = os.Stat(l.lock.Path())
 	if err == nil {

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package lock contains the resources required to create a lock.
 package lock
 
 import (
@@ -17,8 +19,10 @@ import (
 )
 
 var (
+	// ErrLockNotObtained is returned when a lock cannot be returned.
 	ErrLockNotObtained error = errors.New("the lock could not be obtained")
-	ErrUnableToUnlock  error = errors.New("the lock could not be released")
+	// ErrUnableToUnlock is returned when a lock cannot be released.
+	ErrUnableToUnlock error = errors.New("the lock could not be released")
 )
 
 // Locker is the abstract interface for providing a lock client that stores data in the lock

--- a/lock/nillock/nillock.go
+++ b/lock/nillock/nillock.go
@@ -10,44 +10,46 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package nillock contains the resources required to create a nil lock.
 package nillock
 
 import (
 	"github.com/rivian/delta-go/lock"
 )
 
-// / An NilLock implements the Locker interface but is not backed by anything
-// / It is intended for use in a scenario where there is guaranteed to be only one process writing to a delta table
-// / so that locking is not necessary
-// /
-// / WARNING:
-// / It provides NO concurrency support.
-// / It must be used with a single goroutine only.
-// / If used while there are other goroutines or applications (including Spark) writing to the table then
-// / it is likely that commits will be overwritten and lost.
-// / This is intended only for testing, or for use with local tables.
+// An NilLock implements the Locker interface but is not backed by anything
+// It is intended for use in a scenario where there is guaranteed to be only one process writing to a delta table
+// so that locking is not necessary
+//
+// WARNING:
+// It provides NO concurrency support.
+// It must be used with a single goroutine only.
+// If used while there are other goroutines or applications (including Spark) writing to the table then
+// it is likely that commits will be overwritten and lost.
+// This is intended only for testing, or for use with local tables.
 type NilLock struct {
 }
 
 // Compile time check that NilLock implements lock.Locker
 var _ lock.Locker = (*NilLock)(nil)
 
-// Creates a new NilLock instance
+// New reates a new NilLock instance.
 func New() *NilLock {
 	return new(NilLock)
 }
 
-// Creates a new NilLock instance using an existing NilLock instance
+// NewLock creates a new NilLock instance using an existing NilLock instance.
 func (*NilLock) NewLock(key string) (lock.Locker, error) {
 	return new(NilLock), nil
 }
 
-// Does nothing
+// Unlock does nothing.
 func (*NilLock) Unlock() error {
 	return nil
 }
 
-// Always returns true
+// TryLock returns true.
 func (*NilLock) TryLock() (bool, error) {
 	return true, nil
 }

--- a/lock/nillock/nillock_test.go
+++ b/lock/nillock/nillock_test.go
@@ -20,8 +20,8 @@ func TestNilLock(t *testing.T) {
 	if !locked {
 		t.Error("NilLock's TryLock should always succeed")
 	}
-	err = l.Unlock()
-	if err != nil {
+
+	if err := l.Unlock(); err != nil {
 		t.Error(err)
 	}
 }
@@ -48,8 +48,8 @@ func TestNewLock(t *testing.T) {
 	if !locked {
 		t.Error("NilLock's TryLock should always succeed")
 	}
-	err = nl.Unlock()
-	if err != nil {
+
+	if err := nl.Unlock(); err != nil {
 		t.Error(err)
 	}
 }

--- a/lock/redislock/redislock_test.go
+++ b/lock/redislock/redislock_test.go
@@ -76,8 +76,7 @@ func TestRedsyncMultiplePools(t *testing.T) {
 	// Perform an operation.
 	fmt.Println(l.key + ": I have a lock!")
 
-	err = l.Unlock()
-	if err != nil {
+	if err := l.Unlock(); err != nil {
 		t.Error(err)
 	}
 }
@@ -99,8 +98,7 @@ func TestRedsyncSimpleClient(t *testing.T) {
 
 	fmt.Println(l.key + ": I have a lock!")
 
-	err = l.Unlock()
-	if err != nil {
+	if err := l.Unlock(); err != nil {
 		t.Error(err)
 	}
 }

--- a/logstore/commitentry.go
+++ b/logstore/commitentry.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package logstore contains the resources required to create a log store.
 package logstore
 
 import (
@@ -64,7 +66,7 @@ func (ce *CommitEntry) IsComplete() bool {
 	return ce.isComplete
 }
 
-// ExpireTime gets the expiration time of a commit entry.
+// ExpirationTime gets the expiration time of a commit entry.
 func (ce *CommitEntry) ExpirationTime() uint64 {
 	return ce.expirationTime
 }

--- a/logstore/dynamodblogstore/dynamodblogstore_test.go
+++ b/logstore/dynamodblogstore/dynamodblogstore_test.go
@@ -24,23 +24,23 @@ func TestPut(t *testing.T) {
 	o := Options{Client: dynamodbutils.NewMockClient(), TableName: "log_store"}
 	ls, err := New(o)
 	if err != nil {
-		t.Error("Failed to create DynamoDB log store")
+		t.Errorf("Failed to create DynamoDB log store: %v", err)
 	}
 
 	ce := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(ce, true); err != nil {
-		t.Error("Failed to put commit entry")
+		t.Errorf("Failed to put commit entry: %v", err)
 	}
 
 	ce = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), true, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(ce, true); err != nil {
-		t.Error("Failed to overwrite commit entry")
+		t.Errorf("Failed to overwrite commit entry: %v", err)
 	}
 
 	items, ok := ls.client.(*dynamodbutils.MockClient).TablesToItems().Get("log_store")
@@ -53,7 +53,7 @@ func TestPut(t *testing.T) {
 
 	ce, err = ls.Latest(storage.NewPath("usr/local/"))
 	if err != nil {
-		t.Error("Failed to get latest commit entry")
+		t.Errorf("Failed to get latest commit entry: %v", err)
 	}
 	if ce.IsComplete() != true {
 		t.Error("Commit entry should be complete")
@@ -64,28 +64,28 @@ func TestGet(t *testing.T) {
 	o := Options{Client: dynamodbutils.NewMockClient(), TableName: "log_store"}
 	ls, err := New(o)
 	if err != nil {
-		t.Error("Failed to create new DynamoDB log store")
+		t.Errorf("Failed to create new DynamoDB log store: %v", err)
 	}
 
 	ce := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(ce, false); err != nil {
-		t.Error("Failed to put commit entry")
+		t.Errorf("Failed to put commit entry: %v", err)
 	}
 
 	ce = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(ce, false); err == nil {
-		t.Error("Commit entry already exists")
+		t.Errorf("Commit entry already exists: %v", err)
 	}
 
 	ce, err = ls.Get(storage.NewPath("usr/local/"), storage.NewPath("01.json"))
 	if err != nil || ce == nil {
-		t.Error("Failed to get commit entry")
+		t.Errorf("Failed to get commit entry: %v", err)
 	}
 
 	ce, err = ls.Get(storage.NewPath("usr/local/A"), storage.NewPath("01.json"))
@@ -103,28 +103,28 @@ func TestLatest(t *testing.T) {
 	o := Options{Client: dynamodbutils.NewMockClient(), TableName: "log_store"}
 	ls, err := New(o)
 	if err != nil {
-		t.Error("Failed to create DynamoDB log store")
+		t.Errorf("Failed to create DynamoDB log store: %v", err)
 	}
 
 	firstEntry := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(firstEntry, false); err != nil {
-		t.Error("Failed to put commit entry")
+		t.Errorf("Failed to put commit entry: %v", err)
 	}
 
 	secondEntry := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("02.json"), storage.NewPath("02.tmp"), false, uint64(0))
 	if err != nil {
-		t.Error("Failed to create commit entry")
+		t.Errorf("Failed to create commit entry: %v", err)
 	}
 	if err := ls.Put(secondEntry, false); err != nil {
-		t.Error("Failed to put commit entry")
+		t.Errorf("Failed to put commit entry: %v", err)
 	}
 
 	latest, err := ls.Latest(storage.NewPath("usr/local/"))
 	if err != nil || latest == nil {
-		t.Error("Failed to get latest commit entry")
+		t.Errorf("Failed to get latest commit entry: %v", err)
 	}
 	if secondEntry.FileName().Raw != latest.FileName().Raw || secondEntry.TempPath().Raw != latest.TempPath().Raw {
 		t.Error("Got incorrect latest commit entry")

--- a/logstore/logstore.go
+++ b/logstore/logstore.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package logstore contains the resources required to create a log store.
 package logstore
 
 import (
@@ -23,6 +25,7 @@ var (
 	ErrLatestDoesNotExist error = errors.New("the latest item does not exist")
 )
 
+// LogStore uses optimistic concurrency control to commit transactions.
 type LogStore interface {
 	// Put puts a commit entry into a log store in an exclusive way.
 	Put(entry *CommitEntry, overwrite bool) error

--- a/schema.go
+++ b/schema.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package delta contains the resources required to interact with a Delta table.
 package delta
 
 import (
@@ -28,8 +30,8 @@ var (
 	ErrParseSchema error = errors.New("unable to parse schema")
 )
 
-// / Type alias for a string expected to match a GUID/UUID format
-type Guid string
+// GUID is a type alias for a string expected to match a GUID/UUID format.
+type GUID string
 
 // Schema represents the schema of the Delta table.
 type Schema = SchemaTypeStruct
@@ -75,24 +77,40 @@ type SchemaTypeMap struct {
 type SchemaDataTypeName string
 
 const (
-	String    SchemaDataTypeName = "string"    //  * string: utf8
-	Long      SchemaDataTypeName = "long"      //  * long  // undocumented, i64?
-	Integer   SchemaDataTypeName = "integer"   //  * integer: i32
-	Short     SchemaDataTypeName = "short"     //  * short: i16
-	Byte      SchemaDataTypeName = "byte"      //  * byte: i8
-	Float     SchemaDataTypeName = "float"     //  * float: f32
-	Double    SchemaDataTypeName = "double"    //  * double: f64
-	Boolean   SchemaDataTypeName = "boolean"   //  * boolean: bool
-	Binary    SchemaDataTypeName = "binary"    //  * binary: a sequence of binary data
-	Date      SchemaDataTypeName = "date"      //  * date: A calendar date, represented as a year-month-day triple without a timezone
+	// String is the schema data type representing a string.
+	String SchemaDataTypeName = "string" //  * string: utf8
+	// Long is the schema data type representing a long.
+	Long SchemaDataTypeName = "long" //  * long  // undocumented, i64?
+	// Integer is the schema data type representing an integer.
+	Integer SchemaDataTypeName = "integer" //  * integer: i32
+	// Short is the schema data type representing a short.
+	Short SchemaDataTypeName = "short" //  * short: i16
+	// Byte is the schema data type representing a byte.
+	Byte SchemaDataTypeName = "byte" //  * byte: i8
+	// Float is the schema data type representing a float.
+	Float SchemaDataTypeName = "float" //  * float: f32
+	// Double is the schema data type representing a double.
+	Double SchemaDataTypeName = "double" //  * double: f64
+	// Boolean is the schema data type representing a boolean.
+	Boolean SchemaDataTypeName = "boolean" //  * boolean: bool
+	// Binary is the schema data type representing a binary.
+	Binary SchemaDataTypeName = "binary" //  * binary: a sequence of binary data
+	// Date is the schema data type representing a date.
+	Date SchemaDataTypeName = "date" //  * date: A calendar date, represented as a year-month-day triple without a timezone
+	// Timestamp is the schema data type representing a timestamp.
 	Timestamp SchemaDataTypeName = "timestamp" //  * timestamp: Microsecond precision timestamp without a timezone
-	Struct    SchemaDataTypeName = "struct"    //  * struct:
-	Array     SchemaDataTypeName = "array"     //  * array:
-	Map       SchemaDataTypeName = "map"       //  * map:
-	Unknown   SchemaDataTypeName = "unknown"
+	// Struct is the schema data type representing a struct.
+	Struct SchemaDataTypeName = "struct" //  * struct:
+	// Array is the schema data type representing an array.
+	Array SchemaDataTypeName = "array" //  * array:
+	// Map is the schema data type representing a map.
+	Map SchemaDataTypeName = "map" //  * map:
+	// Unknown is the schema data type representing an unknown.
+	Unknown SchemaDataTypeName = "unknown"
 )
 
-func (s *SchemaTypeStruct) Json() []byte {
+// JSON marshals a struct type field in a schema into a JSON object.
+func (s *SchemaTypeStruct) JSON() []byte {
 	containerStruct := SchemaTypeStruct{
 		Type:   Struct,
 		Fields: s.Fields,
@@ -101,6 +119,7 @@ func (s *SchemaTypeStruct) Json() []byte {
 	return b
 }
 
+// UnmarshalJSON unmarshals a JSON object into a schema field.
 func (s *SchemaField) UnmarshalJSON(b []byte) error {
 	data := make(map[string]interface{})
 	if err := json.Unmarshal(b, &data); err != nil {

--- a/schema_test.go
+++ b/schema_test.go
@@ -24,7 +24,7 @@ func TestGetSchema(t *testing.T) {
 	}
 
 	type RowType struct {
-		Id        int       `parquet:"id,snappy" nullable:"false"`
+		ID        int       `parquet:"id,snappy" nullable:"false"`
 		Label     string    `parquet:"label,dict,snappy"`
 		Value     float64   `parquet:"value,snappy"`
 		SubStruct SubStruct `parquet:"sub_struct"`
@@ -48,7 +48,7 @@ func TestGetSchema(t *testing.T) {
 		t.Errorf("expected %v got %v", expectedSchema, schema)
 	}
 
-	b := schema.Json()
+	b := schema.JSON()
 	schemaString := string(b)
 	fmt.Println(schemaString)
 	expectedStr := `{"type":"struct","fields":[{"name":"id","type":"integer","nullable":false,"metadata":{}},{"name":"label","type":"string","nullable":true,"metadata":{}},{"name":"value","type":"double","nullable":true,"metadata":{}},{"name":"sub_struct","type":{"type":"struct","fields":[{"name":"data","type":"string","nullable":true,"metadata":{}}]},"nullable":true,"metadata":{}}]}`
@@ -80,7 +80,7 @@ func TestGetSchemaWithWeirdTypes(t *testing.T) {
 		t.Error("does not contain timestamp field")
 	}
 
-	b := schema.Json()
+	b := schema.JSON()
 	schemaString := string(b)
 	fmt.Println(schemaString)
 	expectedStr := `{"type":"struct","fields":[{"name":"bin","type":"binary","nullable":true,"metadata":{}},{"name":"timestamp","type":"timestamp","nullable":true,"metadata":{}}]}`

--- a/state/filestate/filestate.go
+++ b/state/filestate/filestate.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package filestate contains the resources required to create a file state store.
 package filestate
 
 import (
@@ -22,22 +24,25 @@ import (
 	"github.com/rivian/delta-go/storage"
 )
 
-type FileStateStore struct {
+// Store stores a table's commit state in a file system.
+type Store struct {
 	BaseURI storage.Path
 	Key     string
 }
 
 // Compile time check that FileStateStore implements state.StateStore
-var _ state.StateStore = (*FileStateStore)(nil)
+var _ state.Store = (*Store)(nil)
 
-func New(baseURI storage.Path, key string) *FileStateStore {
-	fs := new(FileStateStore)
+// New creates a new Store instance.
+func New(baseURI storage.Path, key string) *Store {
+	fs := new(Store)
 	fs.BaseURI = baseURI
 	fs.Key = key
 	return fs
 }
 
-func (s *FileStateStore) Get() (state.CommitState, error) {
+// Get retrieves a state store's commit state.
+func (s *Store) Get() (state.CommitState, error) {
 	getPath := filepath.Join(s.BaseURI.Raw, s.Key)
 	var commitState state.CommitState
 	data, err := os.ReadFile(getPath)
@@ -56,7 +61,8 @@ func (s *FileStateStore) Get() (state.CommitState, error) {
 	return commitState, nil
 }
 
-func (s *FileStateStore) Put(commitState state.CommitState) error {
+// Put sets a state store's current commit state.
+func (s *Store) Put(commitState state.CommitState) error {
 	putPath := filepath.Join(s.BaseURI.Raw, s.Key)
 	err := os.MkdirAll(filepath.Dir(putPath), 0755)
 	if err != nil {

--- a/state/localstate/localstate.go
+++ b/state/localstate/localstate.go
@@ -10,36 +10,40 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package localstate contains the resources required to create a localstate.
 package localstate
 
 import (
 	"github.com/rivian/delta-go/state"
 )
 
-// / LocalStateStore stores the version locally.
-// / WARNING
-// / There is no concurrency support for multiple goroutines or processes.
-// / There is no persistence.
-// / This is intended for local use and testing only.
-type LocalStateStore struct {
+// Store stores the version locally.
+// WARNING
+// There is no concurrency support for multiple goroutines or processes.
+// There is no persistence.
+// This is intended for local use and testing only.
+type Store struct {
 	version int64
 }
 
-// / Create a new LocalStateStore with the current table version
-func New(currentTableVersion int64) *LocalStateStore {
-	ls := new(LocalStateStore)
+// New creates a new Store with the current table version.
+func New(currentTableVersion int64) *Store {
+	ls := new(Store)
 	ls.version = currentTableVersion
 	return ls
 }
 
-// Compile time check that LocalStateStore implements state.StateStore
-var _ state.StateStore = (*LocalStateStore)(nil)
+// Compile time check that Store implements state.StateStore
+var _ state.Store = (*Store)(nil)
 
-func (stateStore *LocalStateStore) Get() (state.CommitState, error) {
+// Get retrieves a state store's commit state.
+func (stateStore *Store) Get() (state.CommitState, error) {
 	return state.CommitState{Version: stateStore.version}, nil
 }
 
-func (stateStore *LocalStateStore) Put(commitState state.CommitState) error {
+// Put sets a state store's current commit state.
+func (stateStore *Store) Put(commitState state.CommitState) error {
 	stateStore.version = commitState.Version
 	return nil
 }

--- a/state/localstate/localstate_test.go
+++ b/state/localstate/localstate_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestGetPutVersion(t *testing.T) {
-	localState := new(LocalStateStore)
+	localState := new(Store)
 
 	err := localState.Put(state.CommitState{Version: 1})
 	if err != nil {

--- a/state/redisstate/rediststate.go
+++ b/state/redisstate/rediststate.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package redisstate contains the resources required to create a Redis state store.
 package redisstate
 
 import (
@@ -21,24 +23,27 @@ import (
 	"github.com/rivian/delta-go/state"
 )
 
-type RedisStateStore struct {
+// Store stores a table's commit state in Redis.
+type Store struct {
 	Key         string
 	RedisClient redis.UniversalClient
 	ctx         context.Context
 }
 
 // Compile time check that FileStateStore implements state.StateStore
-var _ state.StateStore = (*RedisStateStore)(nil)
+var _ state.Store = (*Store)(nil)
 
-func New(client redis.UniversalClient, key string) *RedisStateStore {
-	s := new(RedisStateStore)
+// New creates a new Store instance.
+func New(client redis.UniversalClient, key string) *Store {
+	s := new(Store)
 	s.RedisClient = client
 	s.Key = key
 	s.ctx = context.TODO()
 	return s
 }
 
-func (s *RedisStateStore) Get() (state.CommitState, error) {
+// Get retrieves a state store's commit state.
+func (s *Store) Get() (state.CommitState, error) {
 	var commitState state.CommitState
 
 	data, err := s.RedisClient.Get(s.ctx, s.Key).Result()
@@ -57,7 +62,8 @@ func (s *RedisStateStore) Get() (state.CommitState, error) {
 	return commitState, nil
 }
 
-func (s *RedisStateStore) Put(commitState state.CommitState) error {
+// Put sets a state store's current commit state.
+func (s *Store) Put(commitState state.CommitState) error {
 	data, _ := json.Marshal(commitState)
 	err := s.RedisClient.Set(s.ctx, s.Key, data, 0).Err()
 	if err != nil {

--- a/state/state.go
+++ b/state/state.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package state contains the resources required to create a state store.
 package state
 
 import (
@@ -17,8 +19,11 @@ import (
 )
 
 var (
-	ErrorStateIsEmpty     error = errors.New("the state is empty")
-	ErrorCanNotReadState  error = errors.New("the state is could not be read")
+	// ErrorStateIsEmpty is returned when a state is empty.
+	ErrorStateIsEmpty error = errors.New("the state is empty")
+	// ErrorCanNotReadState is returned when a state cannot be read.
+	ErrorCanNotReadState error = errors.New("the state is could not be read")
+	// ErrorCanNotWriteState is returned when a state cannot be written.
 	ErrorCanNotWriteState error = errors.New("the state is could not be written")
 )
 
@@ -28,8 +33,8 @@ type CommitState struct {
 	Version int64 `json:"version"`
 }
 
-// StateStore provides remote state storage for fast lookup on the current commit version
-type StateStore interface {
+// Store provides remote state storage for fast lookup on the current commit version.
+type Store interface {
 	// GetData() retrieves the data cached in the lock.
 	// for a DeltaTable, the data will contain the current or prior locked commit version.
 	Get() (CommitState, error)

--- a/stats.go
+++ b/stats.go
@@ -10,6 +10,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package delta contains the resources required to interact with a Delta table.
 package delta
 
 import (
@@ -43,14 +45,14 @@ const (
 	millisecondsPerSecond   = int64(time.Second / time.Millisecond)
 )
 
-// Json converts the stats into JSON
-func (s *Stats) Json() []byte {
+// JSON converts the stats into JSON
+func (s *Stats) JSON() []byte {
 	b, _ := json.Marshal(s)
 	return b
 }
 
-// StatsFromJson parses JSON into a Stats object
-func StatsFromJson(b []byte) (*Stats, error) {
+// StatsFromJSON parses JSON into a Stats object
+func StatsFromJSON(b []byte) (*Stats, error) {
 	s := new(Stats)
 	var err error
 	if len(b) > 0 {

--- a/stats_test.go
+++ b/stats_test.go
@@ -84,7 +84,7 @@ func TestStatsFromJSON(t *testing.T) {
 
 	statsStr := "{\"numRecords\":123,\"tightBounds\":true,\"minValues\":{\"field1\":\"hello\",\"id\":5},\"maxValues\":{\"field1\":\"world\",\"id\":50},\"nullCount\":{\"field1\":2,\"id\":0}}"
 
-	stats, err := StatsFromJson([]byte(statsStr))
+	stats, err := StatsFromJSON([]byte(statsStr))
 	if err != nil {
 		t.Fatalf("Error in StatsFromJson: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestStatsFromSource(t *testing.T) {
 					t.Errorf("Expected missing columns %v returned %v", tt.wantMissing, missingColumns)
 				}
 			}
-			statsJSON := stats.Json()
+			statsJSON := stats.JSON()
 			statsString := string(statsJSON)
 			if statsString != tt.want {
 				t.Errorf("Expected %s returned %s", tt.want, statsString)

--- a/storage/s3store/s3store_test.go
+++ b/storage/s3store/s3store_test.go
@@ -311,7 +311,7 @@ func TestHead(t *testing.T) {
 	// Verify the metadata returned from Head()
 	objMeta, err := s3Store.Head(path)
 	if err != nil {
-		t.Error("error occurred.")
+		t.Errorf("Failed to retrieve object's metadata: %v", err)
 	}
 	if objMeta.Size != int64(len(data)) {
 		t.Errorf("Size did not match expected. Returned size: %d, Expected size: %d", objMeta.Size, len(data))


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Replaces `staticcheck` with `golangci-lint` because `golangci-lint` includes `staticcheck` as well as other checks.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
