### PR TITLE
ci: use Redis version 6.x for build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,10 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         goVersion: [1.21.x]
+        redis:
+          - 'latest'
 
     steps:
       - name: Set up Redis
         uses: shogo82148/actions-setup-redis@v1
+        with:
+          redis-version: ${{ matrix.redis }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,7 @@ jobs:
         goVersion: [1.21.x]
         redis:
           - 'latest'
+          - '6.x'
 
     steps:
       - name: Set up Redis

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,17 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         goVersion: [1.21.x]
-        redis:
-          - '6.2'
-          - '6.0'
-          - '5.0'
-          - '4.0'
 
     steps:
       - name: Set up Redis
         uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: ${{ matrix.redis }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,8 +15,7 @@ jobs:
       matrix:
         goVersion: [1.21.x]
         redis:
-          - 'latest'
-          - '6.x'
+          - "latest"
 
     steps:
       - name: Set up Redis

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         goVersion: [1.21.x]
         redis:
-          - "latest"
+          - '6.x'
 
     steps:
       - name: Set up Redis


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Uses Redis version 6.x for build instead of specifying multiple Redis versions. Our workflows aren't compatible with the latest version.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] relevant integration tests passing
