### PR TITLE
fix: downgrade to Go version 1.20

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Set up Redis
         uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: ${{ matrix.redis }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,13 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goVersion: [1.21.x]
+        goVersion: [1.20.x]
         redis:
           - '6.x'
 
     steps:
       - name: Set up Redis
         uses: shogo82148/actions-setup-redis@v1
+        with:
+          redis-version: ${{ matrix.redis }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,7 +62,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.20.x
 
           # No need to download cached dependencies when running gofmt.
           cache: false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rivian/delta-go
 
-go 1.21
+go 1.20
 
 require (
 	cirello.io/dynamolock/v2 v2.0.2


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Downgrades to Go version 1.20 to achieve Arrow compatibility.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
