### PR TITLE
refactor!: simplify naming in delta package

### DIFF
--- a/action.go
+++ b/action.go
@@ -126,7 +126,7 @@ func (format *Format) Default() Format {
 
 // / Action that describes the metadata of the table.
 // / This is a top-level action in Delta log entries.
-type Metdata struct {
+type Metadata struct {
 	/// Unique identifier for this table
 	Id uuid.UUID `json:"id" parquet:"-"`
 	/// Parquet library cannot import to UUID
@@ -149,7 +149,7 @@ type Metdata struct {
 
 // Metadata.ToTableMetadata() converts a Metadata to TableMetadata
 // Internally, it converts the schema from a string.
-func (md *Metdata) ToTableMetadata() (TableMetadata, error) {
+func (md *Metadata) ToTableMetadata() (TableMetadata, error) {
 	var err error
 	schema, err := md.GetSchema()
 
@@ -231,12 +231,12 @@ func logEntryFromAction(action Action) ([]byte, error) {
 	switch action.(type) {
 	//TODO: Add errors for missing or null values that are not allowed by the Delta protocol
 	//https://github.com/delta-io/delta/blob/master/PROTOCOL.md#actions
-	case Remove, CommitInfo, Metdata, Protocol, Txn:
+	case Remove, CommitInfo, Metadata, Protocol, Txn:
 		// wrap the action data in a camelCase of the action type
 		key := strcase.ToLowerCamel(reflect.TypeOf(action).Name())
 		m[key] = action
 		log, err = json.Marshal(m)
-	case *Remove, *CommitInfo, *Metdata, *Protocol, *Txn:
+	case *Remove, *CommitInfo, *Metadata, *Protocol, *Txn:
 		key := strcase.ToLowerCamel(reflect.ValueOf(action).Elem().Type().Name())
 		m[key] = action
 		log, err = json.Marshal(m)
@@ -300,7 +300,7 @@ func actionFromLogEntry(unstructuredResult map[string]json.RawMessage) (Action, 
 	} else if marshalledAction, actionFound = unstructuredResult[string(ProtocolActionKey)]; actionFound {
 		action = new(Protocol)
 	} else if marshalledAction, actionFound = unstructuredResult[string(MetaDataActionKey)]; actionFound {
-		action = new(Metdata)
+		action = new(Metadata)
 	} else if marshalledAction, actionFound = unstructuredResult[string(FormatActionKey)]; actionFound {
 		action = new(Format)
 	} else if marshalledAction, actionFound = unstructuredResult[string(TransactionActionKey)]; actionFound {
@@ -343,7 +343,7 @@ func ActionsFromLogEntries(logEntries []byte) ([]Action, error) {
 
 // Returns the table schema from the embedded schema string contained within the metadata
 // action.
-func (m *Metdata) GetSchema() (Schema, error) {
+func (m *Metadata) GetSchema() (Schema, error) {
 	var schema Schema
 	err := json.Unmarshal([]byte(m.SchemaString), &schema)
 	return schema, err

--- a/action_test.go
+++ b/action_test.go
@@ -116,7 +116,7 @@ func TestLogEntryFromActionChangeMetaData(t *testing.T) {
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
 	id, _ := uuid.Parse("af23c9d7-fff1-4a5a-a2c8-55c59bd782aa")
 	schemaString := "..."
-	action := MetaData{
+	action := Metdata{
 		Id:               id,
 		Format:           format,
 		SchemaString:     schemaString,
@@ -415,7 +415,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 func TestMetadataGetSchema(t *testing.T) {
 	// Simple
 	schemaString := "{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}"
-	md := new(MetaData)
+	md := new(Metdata)
 	md.SchemaString = schemaString
 	schema, err := md.GetSchema()
 	if err != nil {

--- a/action_test.go
+++ b/action_test.go
@@ -116,7 +116,7 @@ func TestLogEntryFromActionChangeMetaData(t *testing.T) {
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
 	id, _ := uuid.Parse("af23c9d7-fff1-4a5a-a2c8-55c59bd782aa")
 	schemaString := "..."
-	action := Metdata{
+	action := Metadata{
 		Id:               id,
 		Format:           format,
 		SchemaString:     schemaString,
@@ -415,7 +415,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 func TestMetadataGetSchema(t *testing.T) {
 	// Simple
 	schemaString := "{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}"
-	md := new(Metdata)
+	md := new(Metadata)
 	md.SchemaString = schemaString
 	schema, err := md.GetSchema()
 	if err != nil {

--- a/action_test.go
+++ b/action_test.go
@@ -116,7 +116,7 @@ func TestLogEntryFromActionChangeMetaData(t *testing.T) {
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
 	id, _ := uuid.Parse("af23c9d7-fff1-4a5a-a2c8-55c59bd782aa")
 	schemaString := "..."
-	action := Metadata{
+	action := MetaData{
 		Id:               id,
 		Format:           format,
 		SchemaString:     schemaString,
@@ -415,7 +415,7 @@ func TestActionsFromLogEntries(t *testing.T) {
 func TestMetadataGetSchema(t *testing.T) {
 	// Simple
 	schemaString := "{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}},{\"name\":\"date\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}"
-	md := new(Metadata)
+	md := new(MetaData)
 	md.SchemaString = schemaString
 	schema, err := md.GetSchema()
 	if err != nil {

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -49,7 +49,7 @@ type CheckpointEntry struct {
 	Txn      *Txn      `parquet:"name=txn"`
 	Add      *Add      `parquet:"name=add"`
 	Remove   *Remove   `parquet:"name=remove"`
-	MetaData *Metadata `parquet:"name=metaData"`
+	MetaData *MetaData `parquet:"name=metaData"`
 	Protocol *Protocol `parquet:"name=protocol"`
 	Cdc      *Cdc      `parquet:"-"` // CDC not implemented yet
 }

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -49,7 +49,7 @@ type CheckpointEntry struct {
 	Txn      *Txn      `parquet:"name=txn"`
 	Add      *Add      `parquet:"name=add"`
 	Remove   *Remove   `parquet:"name=remove"`
-	MetaData *MetaData `parquet:"name=metaData"`
+	MetaData *Metdata  `parquet:"name=metaData"`
 	Protocol *Protocol `parquet:"name=protocol"`
 	Cdc      *Cdc      `parquet:"-"` // CDC not implemented yet
 }
@@ -418,7 +418,7 @@ func removeExpiredLogsAndCheckpoints(beforeVersion int64, maxTimestamp time.Time
 
 	candidatesForDeletion := make([]deletionCandidate, 0, 200)
 
-	logIterator := storage.NewListIterator(BaseCommitUri(), store)
+	logIterator := storage.NewListIterator(BaseCommitURI(), store)
 
 	// First collect all the logs/checkpoints that might be eligible for deletion
 	for {
@@ -426,7 +426,7 @@ func removeExpiredLogsAndCheckpoints(beforeVersion int64, maxTimestamp time.Time
 		if errors.Is(err, storage.ErrObjectDoesNotExist) {
 			break
 		}
-		isValid, version := CommitOrCheckpointVersionFromUri(meta.Location)
+		isValid, version := CommitOrCheckpointVersionFromURI(meta.Location)
 		// Spark and Rust clients also use the file's last updated timestamp rather than opening the commit and using internal state
 		if isValid && version < beforeVersion && meta.LastModified.Before(maxTimestamp) {
 			candidatesForDeletion = append(candidatesForDeletion, deletionCandidate{Version: version, Meta: *meta})

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -49,7 +49,7 @@ type CheckpointEntry struct {
 	Txn      *Txn      `parquet:"name=txn"`
 	Add      *Add      `parquet:"name=add"`
 	Remove   *Remove   `parquet:"name=remove"`
-	MetaData *Metdata  `parquet:"name=metaData"`
+	MetaData *Metadata `parquet:"name=metaData"`
 	Protocol *Protocol `parquet:"name=protocol"`
 	Cdc      *Cdc      `parquet:"-"` // CDC not implemented yet
 }

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -123,7 +123,7 @@ func TestSimpleCheckpoint(t *testing.T) {
 			}
 
 			// Does _last_checkpoint point to the checkpoint file
-			table := NewDeltaTable(store, lock, state)
+			table := NewTable(store, lock, state)
 			checkpoints, allReturned, err := table.findLatestCheckpointsForVersion(nil)
 			if err != nil {
 				t.Fatal(err)
@@ -142,7 +142,7 @@ func TestSimpleCheckpoint(t *testing.T) {
 			}
 
 			// Remove the previous log to make sure we use the checkpoint when loading
-			err = store.Delete(CommitUriFromVersion(4))
+			err = store.Delete(CommitURIFromVersion(4))
 			if err != nil {
 				t.Error(err)
 			}
@@ -187,7 +187,7 @@ func TestSimpleCheckpoint(t *testing.T) {
 				}
 			}
 			// Remove the previous log to make sure we use the checkpoint when loading
-			err = store.Delete(CommitUriFromVersion(9))
+			err = store.Delete(CommitURIFromVersion(9))
 			if err != nil {
 				t.Error(err)
 			}
@@ -240,9 +240,9 @@ func getTestRemove(offsetMillis int64, path string) *Remove {
 	return remove
 }
 
-func testDoCommit(t *testing.T, table *DeltaTable, actions []Action) (int64, error) {
+func testDoCommit(t *testing.T, table *Table, actions []Action) (int64, error) {
 	t.Helper()
-	tx := table.CreateTransaction(&DeltaTransactionOptions{})
+	tx := table.CreateTransaction(&TransactionOptions{})
 	tx.AddActions(actions)
 	return tx.Commit(nil, nil)
 }
@@ -261,10 +261,10 @@ func TestTombstones(t *testing.T) {
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointRead = concurrent
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointWrite = concurrent
 
-			table := NewDeltaTable(store, lock, state)
+			table := NewTable(store, lock, state)
 
 			// Set tombstone expiry time to 2 hours
-			metadata := NewDeltaTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 2 hours"})
+			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 2 hours"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -292,7 +292,7 @@ func TestTombstones(t *testing.T) {
 
 			// Load the checkpoint
 			// Remove the previous log to make sure we use the checkpoint when loading
-			err = store.Delete(CommitUriFromVersion(1))
+			err = store.Delete(CommitURIFromVersion(1))
 			if err != nil {
 				t.Error(err)
 			}
@@ -380,9 +380,9 @@ func TestExpiredTombstones(t *testing.T) {
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointRead = concurrent
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointWrite = concurrent
 
-			table := NewDeltaTable(store, lock, state)
+			table := NewTable(store, lock, state)
 
-			metadata := NewDeltaTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -488,9 +488,9 @@ func TestCheckpointNoPartition(t *testing.T) {
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointRead = concurrent
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointWrite = concurrent
 
-			table := NewDeltaTable(store, lock, stateStore)
+			table := NewTable(store, lock, stateStore)
 
-			metadata := NewDeltaTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -568,11 +568,11 @@ func TestMultiPartCheckpoint(t *testing.T) {
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointRead = concurrent
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointWrite = concurrent
 
-			table := NewDeltaTable(store, lock, stateStore)
+			table := NewTable(store, lock, stateStore)
 
 			provider := "tester"
 			options := map[string]string{"hello": "world"}
-			metadata := NewDeltaTableMetaData("test-data", "For testing multi-part checkpoints", Format{Provider: provider, Options: options},
+			metadata := NewTableMetadata("test-data", "For testing multi-part checkpoints", Format{Provider: provider, Options: options},
 				SchemaTypeStruct{}, make([]string, 0), map[string]string{"delta.isTest": "true"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
@@ -640,7 +640,7 @@ func TestMultiPartCheckpoint(t *testing.T) {
 			}
 
 			// Does _last_checkpoint point to the checkpoint file
-			table = NewDeltaTable(store, lock, stateStore)
+			table = NewTable(store, lock, stateStore)
 			checkpoints, allReturned, err := table.findLatestCheckpointsForVersion(nil)
 			if err != nil {
 				t.Fatal(err)
@@ -664,7 +664,7 @@ func TestMultiPartCheckpoint(t *testing.T) {
 			}
 
 			// Remove the previous commit to make sure we load the checkpoint files
-			err = store.Delete(CommitUriFromVersion(11))
+			err = store.Delete(CommitURIFromVersion(11))
 			if err != nil {
 				t.Error(err)
 			}
@@ -956,9 +956,9 @@ func TestCheckpointCleanupExpiredLogs(t *testing.T) {
 		for _, disableCleanupInCheckpointConfig := range tests {
 			store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "")
 
-			table := NewDeltaTable(store, lock, stateStore)
+			table := NewTable(store, lock, stateStore)
 			// Use log expiration of 10 minutes
-			table.Create(DeltaTableMetaData{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 10 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): strconv.FormatBool(enableCleanupInTableConfig)}}, new(Protocol).Default(), CommitInfo{}, []Add{})
+			table.Create(TableMetadata{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 10 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): strconv.FormatBool(enableCleanupInTableConfig)}}, new(Protocol).Default(), CommitInfo{}, []Add{})
 
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
 			add2 := getTestAdd(2 * 60 * 1000) // 2 mins ago
@@ -978,15 +978,15 @@ func TestCheckpointCleanupExpiredLogs(t *testing.T) {
 			}
 			now := time.Now()
 			// With cleanup enabled, 25 and 15 minutes ago should be deleted, 5 should not
-			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(0).Raw), now.Add(-25*time.Minute), now.Add(-25*time.Minute))
+			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(0).Raw), now.Add(-25*time.Minute), now.Add(-25*time.Minute))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(1).Raw), now.Add(-15*time.Minute), now.Add(-15*time.Minute))
+			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(1).Raw), now.Add(-15*time.Minute), now.Add(-15*time.Minute))
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(2).Raw), now.Add(-5*time.Minute), now.Add(-5*time.Minute))
+			err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(2).Raw), now.Add(-5*time.Minute), now.Add(-5*time.Minute))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1064,9 +1064,9 @@ func TestCheckpointCleanupExpiredLogs(t *testing.T) {
 func TestCheckpointCleanupTimeAdjustment(t *testing.T) {
 	store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "")
 
-	table := NewDeltaTable(store, lock, stateStore)
+	table := NewTable(store, lock, stateStore)
 	// Use log expiration of 12 minutes
-	table.Create(DeltaTableMetaData{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 11 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): "true"}}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetadata{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 11 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): "true"}}, Protocol{}, CommitInfo{}, []Add{})
 
 	add1 := getTestAdd(20 * 60 * 1000) // 20 mins ago
 	add2 := getTestAdd(19 * 60 * 1000) // 19 mins ago
@@ -1105,27 +1105,27 @@ func TestCheckpointCleanupTimeAdjustment(t *testing.T) {
 	// 3: 13 min ago
 	// 4: 12 min ago
 	// 5: 6 min ago
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(0).Raw), now.Add(-20*time.Minute), now.Add(-20*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(0).Raw), now.Add(-20*time.Minute), now.Add(-20*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(1).Raw), now.Add(-15*time.Minute), now.Add(-15*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(1).Raw), now.Add(-15*time.Minute), now.Add(-15*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(2).Raw), now.Add(-10*time.Minute), now.Add(-10*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(2).Raw), now.Add(-10*time.Minute), now.Add(-10*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(3).Raw), now.Add(-13*time.Minute), now.Add(-13*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(3).Raw), now.Add(-13*time.Minute), now.Add(-13*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(3).Raw), now.Add(-12*time.Minute), now.Add(-12*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(3).Raw), now.Add(-12*time.Minute), now.Add(-12*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitUriFromVersion(3).Raw), now.Add(-6*time.Minute), now.Add(-6*time.Minute))
+	err = os.Chtimes(filepath.Join(store.BaseURI().Raw, CommitURIFromVersion(3).Raw), now.Add(-6*time.Minute), now.Add(-6*time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1151,21 +1151,21 @@ func TestCheckpointCleanupTimeAdjustment(t *testing.T) {
 		t.Fatal("did not remove version 1")
 	}
 	// We can't load versions 2 and 3 but the logs should persist
-	_, err = store.Head(CommitUriFromVersion(2))
+	_, err = store.Head(CommitURIFromVersion(2))
 	if errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Fatal("should not remove version 2")
 	}
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = store.Head(CommitUriFromVersion(3))
+	_, err = store.Head(CommitURIFromVersion(3))
 	if errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Fatal("should not remove version 3")
 	}
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = store.Head(CommitUriFromVersion(4))
+	_, err = store.Head(CommitURIFromVersion(4))
 	if errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Fatal("should not remove version 4")
 	}
@@ -1234,9 +1234,9 @@ func TestCheckpointUnlockFailure(t *testing.T) {
 func TestCheckpointInvalidVersion(t *testing.T) {
 	store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "")
 
-	table := NewDeltaTable(store, lock, stateStore)
+	table := NewTable(store, lock, stateStore)
 
-	metadata := NewDeltaTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+	metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 	protocol := new(Protocol).Default()
 	protocol.MinReaderVersion = 2
 	protocol.MinWriterVersion = 2

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -264,7 +264,7 @@ func TestTombstones(t *testing.T) {
 			table := NewTable(store, lock, state)
 
 			// Set tombstone expiry time to 2 hours
-			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 2 hours"})
+			metadata := NewTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 2 hours"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -382,7 +382,7 @@ func TestExpiredTombstones(t *testing.T) {
 
 			table := NewTable(store, lock, state)
 
-			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+			metadata := NewTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -490,7 +490,7 @@ func TestCheckpointNoPartition(t *testing.T) {
 
 			table := NewTable(store, lock, stateStore)
 
-			metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+			metadata := NewTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
@@ -572,7 +572,7 @@ func TestMultiPartCheckpoint(t *testing.T) {
 
 			provider := "tester"
 			options := map[string]string{"hello": "world"}
-			metadata := NewTableMetadata("test-data", "For testing multi-part checkpoints", Format{Provider: provider, Options: options},
+			metadata := NewTableMetaData("test-data", "For testing multi-part checkpoints", Format{Provider: provider, Options: options},
 				SchemaTypeStruct{}, make([]string, 0), map[string]string{"delta.isTest": "true"})
 			protocol := new(Protocol).Default()
 			table.Create(*metadata, protocol, CommitInfo{}, make([]Add, 0))
@@ -958,7 +958,7 @@ func TestCheckpointCleanupExpiredLogs(t *testing.T) {
 
 			table := NewTable(store, lock, stateStore)
 			// Use log expiration of 10 minutes
-			table.Create(TableMetadata{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 10 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): strconv.FormatBool(enableCleanupInTableConfig)}}, new(Protocol).Default(), CommitInfo{}, []Add{})
+			table.Create(TableMetaData{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 10 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): strconv.FormatBool(enableCleanupInTableConfig)}}, new(Protocol).Default(), CommitInfo{}, []Add{})
 
 			add1 := getTestAdd(3 * 60 * 1000) // 3 mins ago
 			add2 := getTestAdd(2 * 60 * 1000) // 2 mins ago
@@ -1066,7 +1066,7 @@ func TestCheckpointCleanupTimeAdjustment(t *testing.T) {
 
 	table := NewTable(store, lock, stateStore)
 	// Use log expiration of 12 minutes
-	table.Create(TableMetadata{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 11 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): "true"}}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{Configuration: map[string]string{string(LogRetentionDurationDeltaConfigKey): "interval 11 minutes", string(EnableExpiredLogCleanupDeltaConfigKey): "true"}}, Protocol{}, CommitInfo{}, []Add{})
 
 	add1 := getTestAdd(20 * 60 * 1000) // 20 mins ago
 	add2 := getTestAdd(19 * 60 * 1000) // 19 mins ago
@@ -1236,7 +1236,7 @@ func TestCheckpointInvalidVersion(t *testing.T) {
 
 	table := NewTable(store, lock, stateStore)
 
-	metadata := NewTableMetadata("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
+	metadata := NewTableMetaData("", "", Format{}, GetSchema(new(tombstonesTestData)), make([]string, 0), map[string]string{string(DeletedFileRetentionDurationDeltaConfigKey): "interval 1 minute"})
 	protocol := new(Protocol).Default()
 	protocol.MinReaderVersion = 2
 	protocol.MinWriterVersion = 2

--- a/delta.go
+++ b/delta.go
@@ -809,7 +809,7 @@ func (dtmd *TableMetadata) GetPartitionColDataTypes() map[string]SchemaDataType 
 // / Please not that in case of non-retryable error the temporary commit file such as
 // / `_delta_log/_commit_<uuid>.json` will orphaned in storage.
 type Transaction struct {
-	Table  *Table
+	Table       *Table
 	Actions     []Action
 	Operation   Operation
 	AppMetadata map[string]any
@@ -1167,7 +1167,7 @@ func (transaction *Transaction) SetAppMetadata(appMetadata map[string]any) {
 	transaction.AppMetadata = appMetadata
 }
 
-// Commits the given actions to the Delta log.
+// Commit commits the given actions to the Delta log.
 // This method will retry the transaction commit based on the value of `max_retry_commit_attempts` set in `TransactionOptions`.
 func (transaction *Transaction) Commit(operation Operation, appMetadata map[string]any) (int64, error) {
 	// TODO: stubbing `operation` parameter (which will be necessary for writing the CommitInfo action),
@@ -1358,10 +1358,10 @@ type PreparedCommit struct {
 }
 
 const (
-	defaultMaxRetryCommitAttempts           uint32 = 10000000
-	defaultMaxWriteCommitAttempts           uint32 = 10000000
+	defaultMaxRetryCommitAttempts                uint32 = 10000000
+	defaultMaxWriteCommitAttempts                uint32 = 10000000
 	defaultRetryCommitAttemptsBeforeLoadingTable uint32 = 100
-	defaultMaxRetryLogFixAttempts           uint16 = 3
+	defaultMaxRetryLogFixAttempts                uint16 = 3
 )
 
 // Options for customizing behavior of a `Transaction`

--- a/delta.go
+++ b/delta.go
@@ -769,9 +769,9 @@ func NewTableMetadata(name string, description string, format Format, schema Sch
 }
 
 // TableMetadata.ToMetadata() converts a TableMetadata to Metadata
-func (dtmd *TableMetadata) ToMetadata() Metdata {
+func (dtmd *TableMetadata) ToMetadata() Metadata {
 	createdTime := dtmd.CreatedTime.UnixMilli()
-	metadata := Metdata{
+	metadata := Metadata{
 		Id:               dtmd.Id,
 		IdAsString:       dtmd.Id.String(),
 		Name:             &dtmd.Name,

--- a/delta.go
+++ b/delta.go
@@ -167,7 +167,7 @@ func CommitOrCheckpointVersionFromURI(path storage.Path) (bool, int64) {
 // / Create a Table with version 0 given the provided MetaData, Protocol, and CommitInfo
 // / Note that if the protocol MinReaderVersion or MinWriterVersion is too high, the table will be created
 // / and then an error will be returned
-func (table *Table) Create(metadata TableMetadata, protocol Protocol, commitInfo CommitInfo, addActions []Add) error {
+func (table *Table) Create(metadata TableMetaData, protocol Protocol, commitInfo CommitInfo, addActions []Add) error {
 	meta := metadata.ToMetadata()
 
 	// delta-go commit info will include the delta-go version and timestamp as of now
@@ -732,7 +732,7 @@ func ReadCommitLog(store storage.ObjectStore, location storage.Path) ([]Action, 
 }
 
 // Delta table metadata
-type TableMetadata struct {
+type TableMetaData struct {
 	// Unique identifier for this table
 	Id uuid.UUID
 	/// User-provided identifier for this table
@@ -752,10 +752,10 @@ type TableMetadata struct {
 }
 
 // / Create metadata for a Table from scratch
-func NewTableMetadata(name string, description string, format Format, schema Schema, partitionColumns []string, configuration map[string]string) *TableMetadata {
+func NewTableMetaData(name string, description string, format Format, schema Schema, partitionColumns []string, configuration map[string]string) *TableMetaData {
 	// Reference implementation uses uuid v4 to create GUID:
 	// https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L350
-	metaData := new(TableMetadata)
+	metaData := new(TableMetaData)
 	metaData.Id = uuid.New()
 	metaData.Name = name
 	metaData.Description = description
@@ -768,10 +768,10 @@ func NewTableMetadata(name string, description string, format Format, schema Sch
 
 }
 
-// TableMetadata.ToMetadata() converts a TableMetadata to Metadata
-func (dtmd *TableMetadata) ToMetadata() Metadata {
+// TableMetaData.ToMetaData() converts a TableMetaData to MetaData
+func (dtmd *TableMetaData) ToMetadata() MetaData {
 	createdTime := dtmd.CreatedTime.UnixMilli()
-	metadata := Metadata{
+	metadata := MetaData{
 		Id:               dtmd.Id,
 		IdAsString:       dtmd.Id.String(),
 		Name:             &dtmd.Name,
@@ -785,7 +785,7 @@ func (dtmd *TableMetadata) ToMetadata() Metadata {
 	return metadata
 }
 
-func (dtmd *TableMetadata) GetPartitionColDataTypes() map[string]SchemaDataType {
+func (dtmd *TableMetaData) GetPartitionColDataTypes() map[string]SchemaDataType {
 	partitionColumnsWithType := make(map[string]SchemaDataType, len(dtmd.PartitionColumns))
 	for _, v := range dtmd.Schema.Fields {
 		for _, p := range dtmd.PartitionColumns {

--- a/delta.go
+++ b/delta.go
@@ -1167,7 +1167,7 @@ func (transaction *Transaction) SetAppMetadata(appMetadata map[string]any) {
 	transaction.AppMetadata = appMetadata
 }
 
-// Commit commits the given actions to the Delta log.
+// Commits the given actions to the Delta log.
 // This method will retry the transaction commit based on the value of `max_retry_commit_attempts` set in `TransactionOptions`.
 func (transaction *Transaction) Commit(operation Operation, appMetadata map[string]any) (int64, error) {
 	// TODO: stubbing `operation` parameter (which will be necessary for writing the CommitInfo action),

--- a/delta.go
+++ b/delta.go
@@ -168,7 +168,7 @@ func CommitOrCheckpointVersionFromURI(path storage.Path) (bool, int64) {
 // / Note that if the protocol MinReaderVersion or MinWriterVersion is too high, the table will be created
 // / and then an error will be returned
 func (table *Table) Create(metadata TableMetaData, protocol Protocol, commitInfo CommitInfo, addActions []Add) error {
-	meta := metadata.ToMetadata()
+	meta := metadata.ToMetaData()
 
 	// delta-go commit info will include the delta-go version and timestamp as of now
 	enrichedCommitInfo := maps.Clone(commitInfo)
@@ -769,7 +769,7 @@ func NewTableMetaData(name string, description string, format Format, schema Sch
 }
 
 // TableMetaData.ToMetaData() converts a TableMetaData to MetaData
-func (dtmd *TableMetaData) ToMetadata() MetaData {
+func (dtmd *TableMetaData) ToMetaData() MetaData {
 	createdTime := dtmd.CreatedTime.UnixMilli()
 	metadata := MetaData{
 		Id:               dtmd.Id,

--- a/delta.go
+++ b/delta.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-const deltaClientVersion = "alpha-0.0.0"
+const clientVersion = "alpha-0.0.0"
 
 const maxReaderVersionSupported = 1
 const maxWriterVersionSupported = 1
@@ -56,7 +56,7 @@ var (
 	commitOrCheckpointRegex *regexp.Regexp = regexp.MustCompile(`(\d{20})\.((json)|(checkpoint))`)
 )
 
-type DeltaTable struct {
+type Table struct {
 	// The state of the table as of the most recent loaded Delta log entry.
 	State TableState
 	// The remote store of the state of the table as of the most recent loaded Delta log entry.
@@ -84,12 +84,12 @@ type OptimizeCheckpointConfiguration struct {
 	ConcurrentCheckpointWrite int
 }
 
-// Create a new Delta Table struct without loading any data from backing storage.
+// Create a new Table struct without loading any data from backing storage.
 //
 // NOTE: This is for advanced users. If you don't know why you need to use this method, please
 // call one of the `open_table` helper methods instead.
-func NewDeltaTable(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore) *DeltaTable {
-	table := new(DeltaTable)
+func NewTable(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore) *Table {
+	table := new(Table)
 	table.Store = store
 	table.StateStore = stateStore
 	table.LockClient = lock
@@ -98,8 +98,8 @@ func NewDeltaTable(store storage.ObjectStore, lock lock.Locker, stateStore state
 	return table
 }
 
-func NewDeltaTableWithLogStore(store storage.ObjectStore, lock lock.Locker, logStore logstore.LogStore) *DeltaTable {
-	t := new(DeltaTable)
+func NewTableWithLogStore(store storage.ObjectStore, lock lock.Locker, logStore logstore.LogStore) *Table {
+	t := new(Table)
 	t.State = *NewTableState(-1)
 	t.Store = store
 	t.LockClient = lock
@@ -109,27 +109,27 @@ func NewDeltaTableWithLogStore(store storage.ObjectStore, lock lock.Locker, logS
 	return t
 }
 
-// Creates a new DeltaTransaction for the DeltaTable.
-// The transaction holds a mutable reference to the DeltaTable, preventing other references
+// Creates a new Transaction for the Table.
+// The transaction holds a mutable reference to the Table, preventing other references
 // until the transaction is dropped.
-func (table *DeltaTable) CreateTransaction(options *DeltaTransactionOptions) *DeltaTransaction {
-	return NewDeltaTransaction(table, options)
+func (table *Table) CreateTransaction(options *TransactionOptions) *Transaction {
+	return NewTransaction(table, options)
 }
 
 // / Return the uri of commit version.
-func CommitUriFromVersion(version int64) storage.Path {
+func CommitURIFromVersion(version int64) storage.Path {
 	str := fmt.Sprintf("%020d.json", version)
 	path := storage.PathFromIter([]string{"_delta_log", str})
 	return path
 }
 
 // / The base path of commit uri's
-func BaseCommitUri() storage.Path {
+func BaseCommitURI() storage.Path {
 	return storage.NewPath("_delta_log/")
 }
 
 // / Return true if URI is a valid commit filename (not a checkpoint file, and not a temp commit)
-func IsValidCommitUri(path storage.Path) bool {
+func IsValidCommitURI(path storage.Path) bool {
 	match := commitFileRegex.MatchString(path.Base())
 	return match
 }
@@ -141,7 +141,7 @@ func IsValidCommitOrCheckpointURI(path storage.Path) bool {
 }
 
 // / Return true plus the version if the URI is a valid commit filename
-func CommitVersionFromUri(path storage.Path) (bool, int64) {
+func CommitVersionFromURI(path storage.Path) (bool, int64) {
 	groups := commitFileRegex.FindStringSubmatch(path.Base())
 	if len(groups) == 2 {
 		version, err := strconv.ParseInt(groups[1], 10, 64)
@@ -153,7 +153,7 @@ func CommitVersionFromUri(path storage.Path) (bool, int64) {
 }
 
 // / Return true plus the version if the URI is a valid commit or checkpoint filename
-func CommitOrCheckpointVersionFromUri(path storage.Path) (bool, int64) {
+func CommitOrCheckpointVersionFromURI(path storage.Path) (bool, int64) {
 	groups := commitOrCheckpointRegex.FindStringSubmatch(path.Base())
 	if len(groups) == 5 {
 		version, err := strconv.ParseInt(groups[1], 10, 64)
@@ -164,15 +164,15 @@ func CommitOrCheckpointVersionFromUri(path storage.Path) (bool, int64) {
 	return false, 0
 }
 
-// / Create a DeltaTable with version 0 given the provided MetaData, Protocol, and CommitInfo
+// / Create a Table with version 0 given the provided MetaData, Protocol, and CommitInfo
 // / Note that if the protocol MinReaderVersion or MinWriterVersion is too high, the table will be created
 // / and then an error will be returned
-func (table *DeltaTable) Create(metadata DeltaTableMetaData, protocol Protocol, commitInfo CommitInfo, addActions []Add) error {
-	meta := metadata.ToMetaData()
+func (table *Table) Create(metadata TableMetadata, protocol Protocol, commitInfo CommitInfo, addActions []Add) error {
+	meta := metadata.ToMetadata()
 
-	// delta-rs commit info will include the delta-rs version and timestamp as of now
+	// delta-go commit info will include the delta-go version and timestamp as of now
 	enrichedCommitInfo := maps.Clone(commitInfo)
-	enrichedCommitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", deltaClientVersion)
+	enrichedCommitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", clientVersion)
 	enrichedCommitInfo["timestamp"] = time.Now().UnixMilli()
 
 	actions := []Action{
@@ -188,7 +188,7 @@ func (table *DeltaTable) Create(metadata DeltaTableMetaData, protocol Protocol, 
 	var version int64
 	var err error
 
-	transaction := table.CreateTransaction(NewDeltaTransactionOptions())
+	transaction := table.CreateTransaction(NewTransactionOptions())
 	transaction.AddActions(actions)
 
 	if table.LogStore != nil {
@@ -205,7 +205,7 @@ func (table *DeltaTable) Create(metadata DeltaTableMetaData, protocol Protocol, 
 		zeroState := state.CommitState{
 			Version: table.State.Version,
 		}
-		transaction.DeltaTable.StateStore.Put(zeroState)
+		transaction.Table.StateStore.Put(zeroState)
 		err = transaction.TryCommit(&preparedCommit)
 		if err != nil {
 			return err
@@ -232,14 +232,14 @@ func (table *DeltaTable) Create(metadata DeltaTableMetaData, protocol Protocol, 
 	return err
 }
 
-// / Exists checks if a DeltaTable with version 0 exists in the object store.
-func (table *DeltaTable) Exists() (bool, error) {
-	path := CommitUriFromVersion(0)
+// / Exists checks if a Table with version 0 exists in the object store.
+func (table *Table) Exists() (bool, error) {
+	path := CommitURIFromVersion(0)
 
 	meta, err := table.Store.Head(path)
 	if errors.Is(err, storage.ErrObjectDoesNotExist) {
 		// Fallback: check for other variants of the version
-		logIterator := storage.NewListIterator(BaseCommitUri(), table.Store)
+		logIterator := storage.NewListIterator(BaseCommitURI(), table.Store)
 		for {
 			meta, err := logIterator.Next()
 			if errors.Is(err, storage.ErrObjectDoesNotExist) {
@@ -248,7 +248,7 @@ func (table *DeltaTable) Exists() (bool, error) {
 			if err != nil {
 				return false, err
 			}
-			isCommitOrCheckpoint, _ := CommitOrCheckpointVersionFromUri(meta.Location)
+			isCommitOrCheckpoint, _ := CommitOrCheckpointVersionFromURI(meta.Location)
 			if isCommitOrCheckpoint {
 				return true, nil
 			}
@@ -271,13 +271,13 @@ func (table *DeltaTable) Exists() (bool, error) {
 }
 
 // / Read a commit log and return the actions from the log
-func (table *DeltaTable) ReadCommitVersion(version int64) ([]Action, error) {
-	path := CommitUriFromVersion(version)
+func (table *Table) ReadCommitVersion(version int64) ([]Action, error) {
+	path := CommitURIFromVersion(version)
 	return ReadCommitLog(table.Store, path)
 }
 
 // LatestVersion gets the latest version of a table.
-func (t *DeltaTable) LatestVersion() (int64, error) {
+func (t *Table) LatestVersion() (int64, error) {
 	var (
 		minVersion int64
 		path       = lastCheckpointPath()
@@ -315,7 +315,7 @@ func (t *DeltaTable) LatestVersion() (int64, error) {
 		count      float64
 	)
 	for {
-		if _, err = t.Store.Head(CommitUriFromVersion(maxVersion)); errors.Is(err, storage.ErrObjectDoesNotExist) {
+		if _, err = t.Store.Head(CommitURIFromVersion(maxVersion)); errors.Is(err, storage.ErrObjectDoesNotExist) {
 			break
 		} else {
 			count++
@@ -332,8 +332,8 @@ func (t *DeltaTable) LatestVersion() (int64, error) {
 	for minVersion <= maxVersion {
 		latestVersion = (minVersion + maxVersion) / 2
 
-		_, currErr = t.Store.Head(CommitUriFromVersion(latestVersion))
-		_, nextErr = t.Store.Head(CommitUriFromVersion(latestVersion + 1))
+		_, currErr = t.Store.Head(CommitURIFromVersion(latestVersion))
+		_, nextErr = t.Store.Head(CommitURIFromVersion(latestVersion + 1))
 
 		if currErr == nil && nextErr != nil {
 			break
@@ -349,7 +349,7 @@ func (t *DeltaTable) LatestVersion() (int64, error) {
 func findValidCommitOrCheckpointURI(metadata []storage.ObjectMeta) (bool, int64) {
 	for _, m := range metadata {
 		if IsValidCommitOrCheckpointURI(m.Location) {
-			parsed, version := CommitVersionFromUri(m.Location)
+			parsed, version := CommitVersionFromURI(m.Location)
 			if !parsed {
 				continue
 			}
@@ -361,7 +361,7 @@ func findValidCommitOrCheckpointURI(metadata []storage.ObjectMeta) (bool, int64)
 }
 
 // SyncStateStore syncs the table's state store with its latest version.
-func (t *DeltaTable) SyncStateStore() (err error) {
+func (t *Table) SyncStateStore() (err error) {
 	locked, err := t.LockClient.TryLock()
 	if err != nil {
 		return fmt.Errorf("acquire lock: %w", err)
@@ -391,17 +391,17 @@ func (t *DeltaTable) SyncStateStore() (err error) {
 }
 
 // Load loads the table state using the given configuration
-func (table *DeltaTable) Load(config *OptimizeCheckpointConfiguration) error {
+func (table *Table) Load(config *OptimizeCheckpointConfiguration) error {
 	return table.LoadVersionWithConfiguration(nil, config)
 }
 
 // LoadVersion loads the table state at the specified version using default configuration options
-func (table *DeltaTable) LoadVersion(version *int64) error {
+func (table *Table) LoadVersion(version *int64) error {
 	return table.LoadVersionWithConfiguration(version, nil)
 }
 
 // LoadVersionWithConfiguration loads the table state at the specified version using the given configuration
-func (table *DeltaTable) LoadVersionWithConfiguration(version *int64, config *OptimizeCheckpointConfiguration) error {
+func (table *Table) LoadVersionWithConfiguration(version *int64, config *OptimizeCheckpointConfiguration) error {
 	table.LastCheckPoint = nil
 	table.State = *NewTableState(-1)
 	if config != nil && config.OnDiskOptimization && config.WorkingStore != nil {
@@ -411,7 +411,7 @@ func (table *DeltaTable) LoadVersionWithConfiguration(version *int64, config *Op
 	var err error
 	var checkpointLoadError error
 	if version != nil {
-		commitURI := CommitUriFromVersion(*version)
+		commitURI := CommitURIFromVersion(*version)
 		_, err := table.Store.Head(commitURI)
 		if errors.Is(err, storage.ErrObjectDoesNotExist) {
 			return ErrInvalidVersion
@@ -476,7 +476,7 @@ func (table *DeltaTable) LoadVersionWithConfiguration(version *int64, config *Op
 // / If we are returning all checkpoints at or before the version, allReturned will be true, otherwise it will be false
 // / If we are able to use the _last_checkpoint to retrieve the checkpoint then we will just return that one, and set allReturned to false
 // / If we need to search through the directory for checkpoints, then allReturned will be true if the listing is ordered and false otherwise
-func (table *DeltaTable) findLatestCheckpointsForVersion(version *int64) (checkpoints []CheckPoint, allReturned bool, err error) {
+func (table *Table) findLatestCheckpointsForVersion(version *int64) (checkpoints []CheckPoint, allReturned bool, err error) {
 	// First check if _last_checkpoint exists and is prior to the desired version
 	var errReadingLastCheckpoint error
 	path := lastCheckpointPath()
@@ -496,7 +496,7 @@ func (table *DeltaTable) findLatestCheckpointsForVersion(version *int64) (checkp
 		return nil, false, err
 	}
 
-	logIterator := storage.NewListIterator(BaseCommitUri(), table.Store)
+	logIterator := storage.NewListIterator(BaseCommitURI(), table.Store)
 
 	foundCheckpoints := make([]CheckPoint, 0, 20)
 	listResultsAreOrdered := table.Store.IsListOrdered()
@@ -540,7 +540,7 @@ func (table *DeltaTable) findLatestCheckpointsForVersion(version *int64) (checkp
 		// Finally, if list results are ordered, check if this is a regular commit and the version is greater
 		// than the max version
 		if listResultsAreOrdered && version != nil {
-			isCommit, checkpointVersion := CommitVersionFromUri(meta.Location)
+			isCommit, checkpointVersion := CommitVersionFromURI(meta.Location)
 			if isCommit && checkpointVersion > *version {
 				break
 			}
@@ -565,7 +565,7 @@ func (table *DeltaTable) findLatestCheckpointsForVersion(version *int64) (checkp
 
 // GetCheckpointDataPaths returns the expected file path(s) for the given checkpoint Parquet files
 // If it is a multi-part checkpoint then there will be one path for each part
-func (table *DeltaTable) GetCheckpointDataPaths(checkpoint *CheckPoint) []storage.Path {
+func (table *Table) GetCheckpointDataPaths(checkpoint *CheckPoint) []storage.Path {
 	paths := make([]storage.Path, 0, 10)
 	prefix := fmt.Sprintf("%020d", checkpoint.Version)
 	if checkpoint.Parts == nil {
@@ -580,7 +580,7 @@ func (table *DeltaTable) GetCheckpointDataPaths(checkpoint *CheckPoint) []storag
 }
 
 // Update the table state from the given checkpoint
-func (table *DeltaTable) restoreCheckpoint(checkpoint *CheckPoint, config *OptimizeCheckpointConfiguration) error {
+func (table *Table) restoreCheckpoint(checkpoint *CheckPoint, config *OptimizeCheckpointConfiguration) error {
 	state, err := stateFromCheckpoint(table, checkpoint, config)
 	if err != nil {
 		return err
@@ -589,10 +589,10 @@ func (table *DeltaTable) restoreCheckpoint(checkpoint *CheckPoint, config *Optim
 	return nil
 }
 
-// Updates the DeltaTable to the latest version by incrementally applying newer versions.
+// Updates the Table to the latest version by incrementally applying newer versions.
 // It assumes that the table is already updated to the current version `self.version`.
 // This function does not look for checkpoints
-func (table *DeltaTable) updateIncremental(maxVersion *int64, config *OptimizeCheckpointConfiguration) error {
+func (table *Table) updateIncremental(maxVersion *int64, config *OptimizeCheckpointConfiguration) error {
 	for {
 		if maxVersion != nil && table.State.Version == *maxVersion {
 			break
@@ -631,9 +631,9 @@ func (table *DeltaTable) updateIncremental(maxVersion *int64, config *OptimizeCh
 
 // / Get the actions inside the next commit log if it exists and return the next commit's version and its actions
 // / If the next commit doesn't exist, returns false in the third return parameter
-func (table *DeltaTable) nextCommitDetails() (int64, []Action, bool, error) {
+func (table *Table) nextCommitDetails() (int64, []Action, bool, error) {
 	nextVersion := table.State.Version + 1
-	nextCommitURI := CommitUriFromVersion(nextVersion)
+	nextCommitURI := CommitURIFromVersion(nextVersion)
 	noMoreCommits := false
 	actions, err := ReadCommitLog(table.Store, nextCommitURI)
 	if errors.Is(err, storage.ErrObjectDoesNotExist) {
@@ -647,7 +647,7 @@ func (table *DeltaTable) nextCommitDetails() (int64, []Action, bool, error) {
 // The existing table state will not be used or modified; a new table instance will be opened at the checkpoint version
 // Returns whether the checkpoint was created and any error
 // If the lock cannot be obtained, does not retry
-func (table *DeltaTable) CreateCheckpoint(checkpointLock lock.Locker, checkpointConfiguration *CheckpointConfiguration, version int64) (bool, error) {
+func (table *Table) CreateCheckpoint(checkpointLock lock.Locker, checkpointConfiguration *CheckpointConfiguration, version int64) (bool, error) {
 	return CreateCheckpoint(table.Store, checkpointLock, checkpointConfiguration, version)
 }
 
@@ -694,7 +694,7 @@ func CreateCheckpoint(store storage.ObjectStore, checkpointLock lock.Locker, che
 }
 
 // / Cleanup expired logs before the given checkpoint version, after confirming there is a readable checkpoint
-func validateCheckpointAndCleanup(table *DeltaTable, store storage.ObjectStore, checkpointVersion int64) error {
+func validateCheckpointAndCleanup(table *Table, store storage.ObjectStore, checkpointVersion int64) error {
 	// First confirm there is a valid checkpoint at the given version
 	checkpoints, _, err := table.findLatestCheckpointsForVersion(&checkpointVersion)
 	if err != nil {
@@ -731,13 +731,8 @@ func ReadCommitLog(store storage.ObjectStore, location storage.Path) ([]Action, 
 	return actions, nil
 }
 
-// The URI of the underlying data
-// func (table *DeltaTable) TableUri() string {
-// 	return table.Store.RootURI()
-// }
-
 // Delta table metadata
-type DeltaTableMetaData struct {
+type TableMetadata struct {
 	// Unique identifier for this table
 	Id uuid.UUID
 	/// User-provided identifier for this table
@@ -756,11 +751,11 @@ type DeltaTableMetaData struct {
 	Configuration map[string]string
 }
 
-// / Create metadata for a DeltaTable from scratch
-func NewDeltaTableMetaData(name string, description string, format Format, schema Schema, partitionColumns []string, configuration map[string]string) *DeltaTableMetaData {
+// / Create metadata for a Table from scratch
+func NewTableMetadata(name string, description string, format Format, schema Schema, partitionColumns []string, configuration map[string]string) *TableMetadata {
 	// Reference implementation uses uuid v4 to create GUID:
 	// https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L350
-	metaData := new(DeltaTableMetaData)
+	metaData := new(TableMetadata)
 	metaData.Id = uuid.New()
 	metaData.Name = name
 	metaData.Description = description
@@ -773,10 +768,10 @@ func NewDeltaTableMetaData(name string, description string, format Format, schem
 
 }
 
-// DeltaTableMetaData.ToMetaData() converts a DeltaTableMetaData to MetaData
-func (dtmd *DeltaTableMetaData) ToMetaData() MetaData {
+// TableMetadata.ToMetadata() converts a TableMetadata to Metadata
+func (dtmd *TableMetadata) ToMetadata() Metdata {
 	createdTime := dtmd.CreatedTime.UnixMilli()
-	metadata := MetaData{
+	metadata := Metdata{
 		Id:               dtmd.Id,
 		IdAsString:       dtmd.Id.String(),
 		Name:             &dtmd.Name,
@@ -790,7 +785,7 @@ func (dtmd *DeltaTableMetaData) ToMetaData() MetaData {
 	return metadata
 }
 
-func (dtmd *DeltaTableMetaData) GetPartitionColDataTypes() map[string]SchemaDataType {
+func (dtmd *TableMetadata) GetPartitionColDataTypes() map[string]SchemaDataType {
 	partitionColumnsWithType := make(map[string]SchemaDataType, len(dtmd.PartitionColumns))
 	for _, v := range dtmd.Schema.Fields {
 		for _, p := range dtmd.PartitionColumns {
@@ -802,7 +797,7 @@ func (dtmd *DeltaTableMetaData) GetPartitionColDataTypes() map[string]SchemaData
 	return partitionColumnsWithType
 }
 
-// / Object representing a delta transaction.
+// / Object representing a Delta transaction.
 // / Clients that do not need to mutate action content in case a transaction conflict is encountered
 // / may use the `commit` method and rely on optimistic concurrency to determine the
 // / appropriate Delta version number for a commit. A good example of this type of client is an
@@ -813,12 +808,12 @@ func (dtmd *DeltaTableMetaData) GetPartitionColDataTypes() map[string]SchemaData
 // /
 // / Please not that in case of non-retryable error the temporary commit file such as
 // / `_delta_log/_commit_<uuid>.json` will orphaned in storage.
-type DeltaTransaction struct {
-	DeltaTable  *DeltaTable
+type Transaction struct {
+	Table  *Table
 	Actions     []Action
-	Operation   DeltaOperation
+	Operation   Operation
 	AppMetadata map[string]any
-	Options     *DeltaTransactionOptions
+	Options     *TransactionOptions
 }
 
 // ReadActions gets actions from a file.
@@ -828,14 +823,14 @@ type DeltaTransaction struct {
 // target N.json file more than once. Though data loss will *NOT* occur, readers of N.json
 // may receive an error from S3 as the ETag of N.json was changed. This is safe to
 // retry, so we do so here.
-func (transaction *DeltaTransaction) ReadActions(path storage.Path) ([]Action, error) {
+func (transaction *Transaction) ReadActions(path storage.Path) ([]Action, error) {
 	attempt := 0
 	for {
 		if attempt >= int(transaction.Options.MaxRetryReadAttempts) {
 			return nil, fmt.Errorf("failed to get actions after %d attempts", transaction.Options.MaxRetryReadAttempts)
 		}
 
-		entry, err := transaction.DeltaTable.Store.Get(path)
+		entry, err := transaction.Table.Store.Get(path)
 		if err != nil {
 			attempt++
 			log.Debugf("delta-go: Failed to get log entry. Incrementing attempt number to %d and retrying. %v", attempt, err)
@@ -870,7 +865,7 @@ func (transaction *DeltaTransaction) ReadActions(path storage.Path) ([]Action, e
 //
 // - Step 4: ACKNOWLEDGE the commit.
 //   - Overwrite and complete commit entry E in the log store.
-func (transaction *DeltaTransaction) CommitLogStore() (int64, error) {
+func (transaction *Transaction) CommitLogStore() (int64, error) {
 	attempt := 0
 	for {
 		if attempt >= int(transaction.Options.MaxRetryWriteAttempts) {
@@ -888,38 +883,38 @@ func (transaction *DeltaTransaction) CommitLogStore() (int64, error) {
 	}
 }
 
-func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
+func (t *Transaction) tryCommitLogStore() (version int64, err error) {
 	var currURI storage.Path
-	prevURI, err := t.DeltaTable.LogStore.Latest(t.DeltaTable.Store.BaseURI())
+	prevURI, err := t.Table.LogStore.Latest(t.Table.Store.BaseURI())
 
 	if prevURI != nil {
-		parsed, prevVersion := CommitVersionFromUri(prevURI.FileName())
+		parsed, prevVersion := CommitVersionFromURI(prevURI.FileName())
 		if !parsed {
 			return -1, fmt.Errorf("failed to parse previous version from %s", prevURI.FileName().Raw)
 		}
 
-		currURI = CommitUriFromVersion(prevVersion + 1)
+		currURI = CommitURIFromVersion(prevVersion + 1)
 	} else {
-		if version, err := t.DeltaTable.LatestVersion(); err != nil {
-			currURI = CommitUriFromVersion(0)
+		if version, err := t.Table.LatestVersion(); err != nil {
+			currURI = CommitURIFromVersion(0)
 		} else {
-			uri := CommitUriFromVersion(version).Raw
+			uri := CommitURIFromVersion(version).Raw
 			fileName := storage.NewPath(strings.Split(uri, "_delta_log/")[1])
-			seconds := t.DeltaTable.LogStore.ExpirationDelaySeconds()
+			seconds := t.Table.LogStore.ExpirationDelaySeconds()
 
-			entry, err := logstore.New(t.DeltaTable.Store.BaseURI(), fileName,
+			entry, err := logstore.New(t.Table.Store.BaseURI(), fileName,
 				storage.NewPath("") /* tempPath */, true /* isComplete */, uint64(time.Now().Unix())+seconds)
 			if err != nil {
 				return -1, fmt.Errorf("create first commit entry: %v", err)
 			}
 
-			if err := t.DeltaTable.LogStore.Put(entry, t.DeltaTable.Store.SupportsAtomicPutIfAbsent()); err != nil {
+			if err := t.Table.LogStore.Put(entry, t.Table.Store.SupportsAtomicPutIfAbsent()); err != nil {
 				return -1, fmt.Errorf("put first commit entry: %v", err)
 			}
 			log.Debugf("delta-go: Put completed commit entry for table path %s and file name %s in the empty log store.",
-				t.DeltaTable.Store.BaseURI(), fileName)
+				t.Table.Store.BaseURI(), fileName)
 
-			currURI = CommitUriFromVersion(version + 1)
+			currURI = CommitURIFromVersion(version + 1)
 		}
 	}
 
@@ -935,7 +930,7 @@ func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
 	//
 	// Also note that this lock is for N.json, while the lock used during a recovery is for
 	// N-1.json. Thus, there is no deadlock.
-	lock, err := t.DeltaTable.LockClient.NewLock(t.DeltaTable.Store.BaseURI().Join(currURI).Raw)
+	lock, err := t.Table.LockClient.NewLock(t.Table.Store.BaseURI().Join(currURI).Raw)
 	if err != nil {
 		return -1, fmt.Errorf("create lock: %v", err)
 	}
@@ -951,37 +946,37 @@ func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
 
 	fileName := storage.NewPath(strings.Split(currURI.Raw, "_delta_log/")[1])
 
-	parsed, currVersion := CommitVersionFromUri(currURI)
+	parsed, currVersion := CommitVersionFromURI(currURI)
 	if !parsed {
 		return -1, fmt.Errorf("failed to parse previous version from %s", currURI.Raw)
 	}
 
-	if t.DeltaTable.Store.SupportsAtomicPutIfAbsent() {
+	if t.Table.Store.SupportsAtomicPutIfAbsent() {
 		t.writeActions(currURI, t.Actions)
 
 		return currVersion, nil
 	} else {
 		// Step 0: Fail if N.json already exists in the file system and overwriting is disabled.
-		if _, err = t.DeltaTable.Store.Head(currURI); err == nil {
+		if _, err = t.Table.Store.Head(currURI); err == nil {
 			return -1, errors.New("current version already exists")
 		}
 	}
 
 	// Step 1: Ensure that N-1.json exists.
 	if currVersion > 0 {
-		prevFileName := storage.NewPath(strings.Split(CommitUriFromVersion(currVersion-1).Raw, "_delta_log/")[1])
+		prevFileName := storage.NewPath(strings.Split(CommitURIFromVersion(currVersion-1).Raw, "_delta_log/")[1])
 
-		if prevEntry, err := t.DeltaTable.LogStore.Get(t.DeltaTable.Store.BaseURI(), prevFileName); err != nil {
+		if prevEntry, err := t.Table.LogStore.Get(t.Table.Store.BaseURI(), prevFileName); err != nil {
 			return -1, fmt.Errorf("get previous commit: %v", err)
 		} else if !prevEntry.IsComplete() {
-			if err := t.fixDeltaLog(prevEntry); err != nil {
+			if err := t.fixLog(prevEntry); err != nil {
 				return -1, fmt.Errorf("fix Delta log: %v", err)
 			}
 		}
 	} else {
-		if entry, err := t.DeltaTable.LogStore.Get(t.DeltaTable.Store.BaseURI(), fileName); err == nil {
-			if _, err := t.DeltaTable.Store.Head(currURI); entry.IsComplete() && err != nil {
-				return -1, fmt.Errorf("old entries for table %s still in log store", t.DeltaTable.Store.BaseURI())
+		if entry, err := t.Table.LogStore.Get(t.Table.Store.BaseURI(), fileName); err == nil {
+			if _, err := t.Table.Store.Head(currURI); entry.IsComplete() && err != nil {
+				return -1, fmt.Errorf("old entries for table %s still in log store", t.Table.Store.BaseURI())
 			}
 		}
 	}
@@ -993,7 +988,7 @@ func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
 	}
 	relativeTempPath := storage.NewPath("_delta_log").Join(tempPath)
 
-	entry, err := logstore.New(t.DeltaTable.Store.BaseURI(), fileName, tempPath, false /* isComplete */, 0 /* expirationTime */)
+	entry, err := logstore.New(t.Table.Store.BaseURI(), fileName, tempPath, false /* isComplete */, 0 /* expirationTime */)
 	if err != nil {
 		return -1, fmt.Errorf("create commit entry: %v", err)
 	}
@@ -1003,7 +998,7 @@ func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
 	}
 
 	// Step 2.2: Create uncompleted commit entry E(N, T(N)).
-	if err := t.DeltaTable.LogStore.Put(entry, t.DeltaTable.Store.SupportsAtomicPutIfAbsent()); err != nil {
+	if err := t.Table.LogStore.Put(entry, t.Table.Store.SupportsAtomicPutIfAbsent()); err != nil {
 		return -1, fmt.Errorf("put uncompleted commit entry: %v", err)
 	}
 
@@ -1021,29 +1016,29 @@ func (t *DeltaTransaction) tryCommitLogStore() (version int64, err error) {
 	return currVersion, nil
 }
 
-func (t *DeltaTransaction) complete(entry *logstore.CommitEntry) error {
-	seconds := t.DeltaTable.LogStore.ExpirationDelaySeconds()
+func (t *Transaction) complete(entry *logstore.CommitEntry) error {
+	seconds := t.Table.LogStore.ExpirationDelaySeconds()
 	entry, err := entry.Complete(seconds)
 	if err != nil {
 		return fmt.Errorf("complete commit entry: %v", err)
 	}
 
-	if err := t.DeltaTable.LogStore.Put(entry, true); err != nil {
+	if err := t.Table.LogStore.Put(entry, true); err != nil {
 		return fmt.Errorf("put completed commit entry: %v", err)
 	}
 
 	return nil
 }
 
-func (t *DeltaTransaction) copyTempFile(src storage.Path, dst storage.Path) error {
-	return t.DeltaTable.Store.RenameIfNotExists(src, dst)
+func (t *Transaction) copyTempFile(src storage.Path, dst storage.Path) error {
+	return t.Table.Store.RenameIfNotExists(src, dst)
 }
 
-func (t *DeltaTransaction) createTempPath(path storage.Path) (storage.Path, error) {
+func (t *Transaction) createTempPath(path storage.Path) (storage.Path, error) {
 	return storage.NewPath(fmt.Sprintf(".tmp/%s.%s", path.Raw, uuid.New().String())), nil
 }
 
-func (t *DeltaTransaction) fixDeltaLog(entry *logstore.CommitEntry) (err error) {
+func (t *Transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 	if entry.IsComplete() {
 		return nil
 	}
@@ -1053,7 +1048,7 @@ func (t *DeltaTransaction) fixDeltaLog(entry *logstore.CommitEntry) (err error) 
 		return fmt.Errorf("get absolute file path: %v", err)
 	}
 
-	lock, err := t.DeltaTable.LockClient.NewLock(filePath.Raw)
+	lock, err := t.Table.LockClient.NewLock(filePath.Raw)
 	if err != nil {
 		return fmt.Errorf("create lock: %v", err)
 	}
@@ -1069,13 +1064,13 @@ func (t *DeltaTransaction) fixDeltaLog(entry *logstore.CommitEntry) (err error) 
 
 	attempt, copied := 0, false
 	for {
-		if attempt >= int(t.Options.MaxRetryDeltaLogFixAttempts) {
-			return fmt.Errorf("failed to fix Delta log after %d attempts", t.Options.MaxRetryDeltaLogFixAttempts)
+		if attempt >= int(t.Options.MaxRetryLogFixAttempts) {
+			return fmt.Errorf("failed to fix Delta log after %d attempts", t.Options.MaxRetryLogFixAttempts)
 		}
 
 		log.Infof("delta-go: Trying to fix %s.", entry.FileName().Raw)
 
-		if _, err = t.DeltaTable.Store.Head(filePath); !copied && err != nil {
+		if _, err = t.Table.Store.Head(filePath); !copied && err != nil {
 			tempPath, err := entry.AbsoluteTempPath()
 			if err != nil {
 				attempt++
@@ -1106,38 +1101,38 @@ func (t *DeltaTransaction) fixDeltaLog(entry *logstore.CommitEntry) (err error) 
 	}
 }
 
-func (transaction *DeltaTransaction) writeActions(path storage.Path, actions []Action) error {
+func (transaction *Transaction) writeActions(path storage.Path, actions []Action) error {
 	// Serialize all actions that are part of this log entry.
 	entry, err := LogEntryFromActions(actions)
 	if err != nil {
 		return errors.New("failed to serialize actions")
 	}
 
-	return transaction.DeltaTable.Store.Put(path, entry)
+	return transaction.Table.Store.Put(path, entry)
 }
 
-// / Creates a new delta transaction.
-// / Holds a mutable reference to the delta table to prevent outside mutation while a transaction commit is in progress.
-// / Transaction behavior may be customized by passing an instance of `DeltaTransactionOptions`.
-func NewDeltaTransaction(deltaTable *DeltaTable, options *DeltaTransactionOptions) *DeltaTransaction {
-	transaction := new(DeltaTransaction)
-	transaction.DeltaTable = deltaTable
+// / Creates a new Delta transaction.
+// / Holds a mutable reference to the Delta table to prevent outside mutation while a transaction commit is in progress.
+// / Transaction behavior may be customized by passing an instance of `TransactionOptions`.
+func NewTransaction(table *Table, options *TransactionOptions) *Transaction {
+	transaction := new(Transaction)
+	transaction.Table = table
 	transaction.Options = options
 	return transaction
 }
 
 // / Add an arbitrary "action" to the actions associated with this transaction
-func (transaction *DeltaTransaction) AddAction(action Action) {
+func (transaction *Transaction) AddAction(action Action) {
 	transaction.Actions = append(transaction.Actions, action)
 }
 
 // / Add an arbitrary number of actions to the actions associated with this transaction
-func (transaction *DeltaTransaction) AddActions(actions []Action) {
+func (transaction *Transaction) AddActions(actions []Action) {
 	transaction.Actions = append(transaction.Actions, actions...)
 }
 
 // AddCommitInfo adds a `commitInfo` action to a transaction's actions if not already present.
-func (t *DeltaTransaction) AddCommitInfoIfNotPresent() {
+func (t *Transaction) AddCommitInfoIfNotPresent() {
 	found := false
 	for _, action := range t.Actions {
 		switch action.(type) {
@@ -1149,7 +1144,7 @@ func (t *DeltaTransaction) AddCommitInfoIfNotPresent() {
 	if !found {
 		commitInfo := make(CommitInfo)
 		commitInfo["timestamp"] = time.Now().UnixMilli()
-		commitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", deltaClientVersion)
+		commitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", clientVersion)
 
 		if t.Operation != nil {
 			maps.Copy(commitInfo, t.Operation.GetCommitInfo())
@@ -1163,18 +1158,18 @@ func (t *DeltaTransaction) AddCommitInfoIfNotPresent() {
 }
 
 // SetOperation sets the Delta operation for this transaction.
-func (transaction *DeltaTransaction) SetOperation(operation DeltaOperation) {
+func (transaction *Transaction) SetOperation(operation Operation) {
 	transaction.Operation = operation
 }
 
 // SetAppMetadata sets the app metadata for this transaction.
-func (transaction *DeltaTransaction) SetAppMetadata(appMetadata map[string]any) {
+func (transaction *Transaction) SetAppMetadata(appMetadata map[string]any) {
 	transaction.AppMetadata = appMetadata
 }
 
-// Commits the given actions to the delta log.
-// This method will retry the transaction commit based on the value of `max_retry_commit_attempts` set in `DeltaTransactionOptions`.
-func (transaction *DeltaTransaction) Commit(operation DeltaOperation, appMetadata map[string]any) (int64, error) {
+// Commits the given actions to the Delta log.
+// This method will retry the transaction commit based on the value of `max_retry_commit_attempts` set in `TransactionOptions`.
+func (transaction *Transaction) Commit(operation Operation, appMetadata map[string]any) (int64, error) {
 	// TODO: stubbing `operation` parameter (which will be necessary for writing the CommitInfo action),
 	// but leaving it unused for now. `CommitInfo` is a fairly dynamic data structure so we should work
 	// out the data structure approach separately.
@@ -1197,17 +1192,17 @@ func (transaction *DeltaTransaction) Commit(operation DeltaOperation, appMetadat
 	PreparedCommit, err := transaction.PrepareCommit(operation, appMetadata)
 	if err != nil {
 		log.Debugf("delta-go: PrepareCommit attempt failed. %v", err)
-		return transaction.DeltaTable.State.Version, err
+		return transaction.Table.State.Version, err
 	}
 
 	err = transaction.TryCommitLoop(&PreparedCommit)
-	return transaction.DeltaTable.State.Version, err
+	return transaction.Table.State.Version, err
 }
 
 // / Low-level transaction API. Creates a temporary commit file. Once created,
 // / the transaction object could be dropped and the actual commit could be executed
-// / with `DeltaTable.try_commit_transaction`.
-func (transaction *DeltaTransaction) PrepareCommit(operation DeltaOperation, appMetadata map[string]any) (PreparedCommit, error) {
+// / with `Table.try_commit_transaction`.
+func (transaction *Transaction) PrepareCommit(operation Operation, appMetadata map[string]any) (PreparedCommit, error) {
 	anyCommitInfo := false
 	for _, action := range transaction.Actions {
 		switch action.(type) {
@@ -1219,7 +1214,7 @@ func (transaction *DeltaTransaction) PrepareCommit(operation DeltaOperation, app
 	if !anyCommitInfo {
 		commitInfo := make(CommitInfo)
 		commitInfo["timestamp"] = time.Now().UnixMilli()
-		commitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", deltaClientVersion)
+		commitInfo["clientVersion"] = fmt.Sprintf("delta-go.%s", clientVersion)
 		if operation != nil {
 			maps.Copy(commitInfo, operation.GetCommitInfo())
 		}
@@ -1235,15 +1230,15 @@ func (transaction *DeltaTransaction) PrepareCommit(operation DeltaOperation, app
 		return PreparedCommit{}, nil
 	}
 
-	// Write delta log entry as temporary file to storage. For the actual commit,
-	// the temporary file is moved (atomic rename) to the delta log folder within `commit` function.
+	// Write Delta log entry as temporary file to storage. For the actual commit,
+	// the temporary file is moved (atomic rename) to the Delta log folder within `commit` function.
 	token := uuid.New().String()
 	fileName := fmt.Sprintf("_commit_%s.json.tmp", token)
 	// TODO: Open question, should storagePath use the basePath for the transaction or just hard code the _delta_log path?
 	path := storage.Path{Raw: filepath.Join("_delta_log", fileName)}
 	commit := PreparedCommit{URI: path}
 
-	err = transaction.DeltaTable.Store.Put(path, logEntry)
+	err = transaction.Table.Store.Put(path, logEntry)
 	if err != nil {
 		return commit, err
 	}
@@ -1252,7 +1247,7 @@ func (transaction *DeltaTransaction) PrepareCommit(operation DeltaOperation, app
 }
 
 // TryCommitLoop loads metadata from lock containing the latest locked version and tries to obtain the lock and commit for the version + 1 in a loop
-func (transaction *DeltaTransaction) TryCommitLoop(commit *PreparedCommit) error {
+func (transaction *Transaction) TryCommitLoop(commit *PreparedCommit) error {
 	attemptNumber := 0
 	for {
 		if attemptNumber > 0 {
@@ -1274,9 +1269,9 @@ func (transaction *DeltaTransaction) TryCommitLoop(commit *PreparedCommit) error
 				if transaction.Options.RetryCommitAttemptsBeforeLoadingTable > 0 &&
 					attemptNumber%int(transaction.Options.RetryCommitAttemptsBeforeLoadingTable) == 0 {
 					// Every 100 attempts, sync the table's state store with its latest version.
-					err := transaction.DeltaTable.SyncStateStore()
+					err := transaction.Table.SyncStateStore()
 					if err != nil {
-						log.Debugf("delta-go: DeltaTable.SyncStateStore() failed with '%v'.", err)
+						log.Debugf("delta-go: Table.SyncStateStore() failed with '%v'.", err)
 					}
 				}
 			} else {
@@ -1292,14 +1287,14 @@ func (transaction *DeltaTransaction) TryCommitLoop(commit *PreparedCommit) error
 }
 
 // TryCommitLoop: Loads metadata from lock containing the latest locked version and tries to obtain the lock and commit for the version + 1 in a loop
-func (transaction *DeltaTransaction) TryCommit(commit *PreparedCommit) (err error) {
+func (transaction *Transaction) TryCommit(commit *PreparedCommit) (err error) {
 	// Step 1) Acquire Lock
-	locked, err := transaction.DeltaTable.LockClient.TryLock()
+	locked, err := transaction.Table.LockClient.TryLock()
 	// Step 5) Always Release Lock
-	// defer transaction.DeltaTable.LockClient.Unlock()
+	// defer transaction.Table.LockClient.Unlock()
 	defer func() {
 		// Defer the unlock and overwrite any errors if unlock fails
-		if unlockErr := transaction.DeltaTable.LockClient.Unlock(); unlockErr != nil {
+		if unlockErr := transaction.Table.LockClient.Unlock(); unlockErr != nil {
 			log.Debugf("delta-go: Unlock attempt failed. %v", unlockErr)
 			err = unlockErr
 		}
@@ -1311,7 +1306,7 @@ func (transaction *DeltaTransaction) TryCommit(commit *PreparedCommit) (err erro
 
 	if locked {
 		// 2) Lookup the latest prior state
-		priorState, err := transaction.DeltaTable.StateStore.Get()
+		priorState, err := transaction.Table.StateStore.Get()
 		if err != nil {
 			// Failed on state store get, fallback to using the local version
 			log.Debugf("delta-go: StateStore Get() attempt failed. %v", err)
@@ -1321,13 +1316,13 @@ func (transaction *DeltaTransaction) TryCommit(commit *PreparedCommit) (err erro
 		// 4) Update the state with the latest tried, even in the case that the
 		// RenameNotExists was unsuccessful, this ensures that the next try increments the version
 		// Take the max of the local state and remote state version in the case that the remote state is not accessible.
-		version := max(priorState.Version, transaction.DeltaTable.State.Version) + 1
-		transaction.DeltaTable.State.Version = version
+		version := max(priorState.Version, transaction.Table.State.Version) + 1
+		transaction.Table.State.Version = version
 		newState := state.CommitState{
 			Version: version,
 		}
 		defer func() {
-			if putErr := transaction.DeltaTable.StateStore.Put(newState); putErr != nil {
+			if putErr := transaction.Table.StateStore.Put(newState); putErr != nil {
 				log.Debugf("delta-go: StateStore Put() attempt failed. %v", putErr)
 				err = putErr
 			}
@@ -1335,8 +1330,8 @@ func (transaction *DeltaTransaction) TryCommit(commit *PreparedCommit) (err erro
 
 		// 3) Try to Rename the file
 		from := storage.NewPath(commit.URI.Raw)
-		to := CommitUriFromVersion(version)
-		err = transaction.DeltaTable.Store.RenameIfNotExists(from, to)
+		to := CommitURIFromVersion(version)
+		err = transaction.Table.Store.RenameIfNotExists(from, to)
 		if err != nil {
 			log.Debugf("delta-go: RenameIfNotExists(from=%s, to=%s) attempt failed. %v", from.Raw, to.Raw, err)
 			return err
@@ -1356,21 +1351,21 @@ func max[T constraints.Ordered](a, b T) T {
 	return b
 }
 
-// Holds the uri to prepared commit temporary file created with `DeltaTransaction.prepare_commit`.
-// Once created, the actual commit could be executed with `DeltaTransaction.try_commit`.
+// Holds the uri to prepared commit temporary file created with `Transaction.prepare_commit`.
+// Once created, the actual commit could be executed with `Transaction.try_commit`.
 type PreparedCommit struct {
 	URI storage.Path
 }
 
 const (
-	defaultDeltaMaxRetryCommitAttempts           uint32 = 10000000
-	defaultDeltaMaxWriteCommitAttempts           uint32 = 10000000
+	defaultMaxRetryCommitAttempts           uint32 = 10000000
+	defaultMaxWriteCommitAttempts           uint32 = 10000000
 	defaultRetryCommitAttemptsBeforeLoadingTable uint32 = 100
-	defaultMaxRetryDeltaLogFixAttempts           uint16 = 3
+	defaultMaxRetryLogFixAttempts           uint16 = 3
 )
 
-// Options for customizing behavior of a `DeltaTransaction`
-type DeltaTransactionOptions struct {
+// Options for customizing behavior of a `Transaction`
+type TransactionOptions struct {
 	// number of retry attempts allowed when committing a transaction
 	MaxRetryCommitAttempts uint32
 	// RetryWaitDuration sets the amount of times between retry's on the transaction
@@ -1383,23 +1378,23 @@ type DeltaTransactionOptions struct {
 	// than using the state store
 	RetryCommitAttemptsBeforeLoadingTable uint32
 	// Number of retry attempts allowed when fixing the Delta log
-	MaxRetryDeltaLogFixAttempts uint16
+	MaxRetryLogFixAttempts uint16
 }
 
-// NewDeltaTransactionOptions sets the default transaction options.
-func NewDeltaTransactionOptions() *DeltaTransactionOptions {
-	return &DeltaTransactionOptions{MaxRetryCommitAttempts: defaultDeltaMaxRetryCommitAttempts, MaxRetryWriteAttempts: defaultDeltaMaxWriteCommitAttempts, MaxRetryDeltaLogFixAttempts: defaultMaxRetryDeltaLogFixAttempts, RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable}
+// NewTransactionOptions sets the default transaction options.
+func NewTransactionOptions() *TransactionOptions {
+	return &TransactionOptions{MaxRetryCommitAttempts: defaultMaxRetryCommitAttempts, MaxRetryWriteAttempts: defaultMaxWriteCommitAttempts, MaxRetryLogFixAttempts: defaultMaxRetryLogFixAttempts, RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable}
 }
 
 // OpenTableWithVersion loads the table at this specific version
 // If the table reader or writer version is greater than the client supports, the table will still be opened, but an error will also be returned
-func OpenTableWithVersion(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, version int64) (*DeltaTable, error) {
+func OpenTableWithVersion(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, version int64) (*Table, error) {
 	return OpenTableWithVersionAndConfiguration(store, lock, stateStore, version, nil)
 }
 
 // OpenTableWithVersionAndConfiguration loads the table at this specific version using the given configuration for optimization settings
-func OpenTableWithVersionAndConfiguration(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, version int64, config *OptimizeCheckpointConfiguration) (*DeltaTable, error) {
-	table := NewDeltaTable(store, lock, stateStore)
+func OpenTableWithVersionAndConfiguration(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, version int64, config *OptimizeCheckpointConfiguration) (*Table, error) {
+	table := NewTable(store, lock, stateStore)
 	err := table.LoadVersionWithConfiguration(&version, config)
 	if err != nil {
 		return nil, err
@@ -1418,13 +1413,13 @@ func OpenTableWithVersionAndConfiguration(store storage.ObjectStore, lock lock.L
 
 // OpenTable loads the latest version of the table
 // If the table reader or writer version is greater than the client supports, the table will still be opened, but an error will also be returned
-func OpenTable(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore) (*DeltaTable, error) {
+func OpenTable(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore) (*Table, error) {
 	return OpenTableWithConfiguration(store, lock, stateStore, nil)
 }
 
 // OpenTableWithConfiguration loads the latest version of the table, using the given configuration for optimization settings
-func OpenTableWithConfiguration(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, config *OptimizeCheckpointConfiguration) (*DeltaTable, error) {
-	table := NewDeltaTable(store, lock, stateStore)
+func OpenTableWithConfiguration(store storage.ObjectStore, lock lock.Locker, stateStore state.StateStore, config *OptimizeCheckpointConfiguration) (*Table, error) {
+	table := NewTable(store, lock, stateStore)
 	err := table.LoadVersionWithConfiguration(nil, config)
 	if err != nil {
 		return nil, err

--- a/delta_test.go
+++ b/delta_test.go
@@ -1976,7 +1976,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 
 	var (
 		wg                sync.WaitGroup
-		transactions      = 500
+		transactions      = 100
 		firstTransaction  *Transaction
 		secondTransaction *Transaction
 	)
@@ -2263,7 +2263,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 
 	var (
 		wg                sync.WaitGroup
-		transactions      = 500
+		transactions      = 100
 		firstTransaction  *Transaction
 		secondTransaction *Transaction
 	)

--- a/delta_test.go
+++ b/delta_test.go
@@ -92,7 +92,7 @@ func TestDeltaTransactionPrepareCommit(t *testing.T) {
 
 func TestDeltaTableReadCommitVersion(t *testing.T) {
 	table, _, _ := setupTest(t)
-	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestDeltaTableReadCommitVersion(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*Metadata)
+	_, ok = actions[2].(*MetaData)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}
@@ -139,7 +139,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	format := new(Format).Default()
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
-	metadata := NewTableMetadata("Test Table", "", format, schema, []string{}, config)
+	metadata := NewTableMetaData("Test Table", "", format, schema, []string{}, config)
 	protocol := new(Protocol).Default()
 	stats := Stats{NumRecords: 1, MinValues: map[string]any{"first_column": 1}}
 	path := "part-123.snappy.parquet"
@@ -182,7 +182,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*Metadata)
+	_, ok = actions[2].(*MetaData)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}
@@ -208,7 +208,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 
 func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	table, _, _ := setupTest(t)
-	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -331,7 +331,7 @@ func TestTryCommitWithNilLockAndLocalState(t *testing.T) {
 	lock := nillock.New()
 	table := NewTable(store, lock, storeState)
 
-	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -369,7 +369,7 @@ func TestDeltaTableCreate(t *testing.T) {
 	format := new(Format).Default()
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
-	metadata := NewTableMetadata("Test Table", "", format, schema, []string{}, config)
+	metadata := NewTableMetaData("Test Table", "", format, schema, []string{}, config)
 	protocol := new(Protocol).Default()
 	add := Add{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
@@ -405,7 +405,7 @@ func TestDeltaTableExists(t *testing.T) {
 	if tableExists {
 		t.Errorf("table should not exist")
 	}
-	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 
 	err = table.Create(*metadata, Protocol{}, make(map[string]any), []Add{})
 	if err != nil {
@@ -513,7 +513,7 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 	lock := filelock.New(tmpPath, "_delta_log/_commit.lock", filelock.Options{})
 	table := NewTable(s3Store, lock, state)
 
-	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 
 	err = table.Create(*metadata, Protocol{}, make(map[string]any), []Add{})
 	if err != nil {
@@ -586,7 +586,7 @@ func TestDeltaTableTryCommitLoop(t *testing.T) {
 
 func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
-	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 5, RetryWaitDuration: time.Second})
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -635,7 +635,7 @@ func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 
 func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
-	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{
 		MaxRetryCommitAttempts:                5, //Should break on max attempts if the latest version logic fails
 		RetryWaitDuration:                     time.Second,
@@ -701,7 +701,7 @@ func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 func TestCommitConcurrent(t *testing.T) {
 	// log.SetLevel(log.DebugLevel)
 	table, state, tmpDir := setupTest(t)
-	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 	err := table.Create(*metadata, Protocol{}, CommitInfo{}, []Add{})
 	if err != nil {
 		t.Error(err)
@@ -784,7 +784,7 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 		PartitionValues:  make(map[string]string),
 	}
 
-	metadata := NewTableMetadata("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
+	metadata := NewTableMetaData("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
 	err = table.Create(*metadata, new(Protocol).Default(), CommitInfo{}, []Add{add})
 	if err != nil {
 		t.Error(err)
@@ -892,7 +892,7 @@ func TestCreateWithParquet(t *testing.T) {
 		PartitionValues:  make(map[string]string),
 	}
 
-	metadata := NewTableMetadata("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
+	metadata := NewTableMetaData("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
 	err = table.Create(*metadata, new(Protocol).Default(), CommitInfo{}, []Add{add})
 	if err != nil {
 		t.Error(err)
@@ -1185,7 +1185,7 @@ func TestLatestVersion(t *testing.T) {
 		state    = filestate.New(path, "_delta_log/_commit.state")
 		lock     = filelock.New(path, "_delta_log/_commit.lock", filelock.Options{})
 		table    = NewTable(store, lock, state)
-		metadata = NewTableMetadata("test", "", new(Format).Default(), SchemaTypeStruct{}, nil, make(map[string]string))
+		metadata = NewTableMetaData("test", "", new(Format).Default(), SchemaTypeStruct{}, nil, make(map[string]string))
 	)
 
 	if _, err := table.LatestVersion(); !errors.Is(err, ErrNotATable) { // if NO error
@@ -1426,7 +1426,7 @@ func TestLoadVersion(t *testing.T) {
 	}
 	provider := "parquet"
 	options := map[string]string{}
-	expectedState.CurrentMetadata = NewTableMetadata("", "", Format{Provider: provider, Options: options}, schema, []string{"date"}, make(map[string]string))
+	expectedState.CurrentMetadata = NewTableMetaData("", "", Format{Provider: provider, Options: options}, schema, []string{"date"}, make(map[string]string))
 	expectedState.CurrentMetadata.CreatedTime = time.Unix(1627668675, 432000000)
 	expectedState.CurrentMetadata.Id = uuid.MustParse("853536c9-0abe-4e66-9732-1718e542e6aa")
 
@@ -1486,7 +1486,7 @@ func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, tab
 		}}
 
 	config := make(map[string]string)
-	metadata := NewTableMetadata(
+	metadata := NewTableMetaData(
 		"test",
 		"This is a test table.",
 		new(Format).Default(),

--- a/delta_test.go
+++ b/delta_test.go
@@ -119,7 +119,7 @@ func TestDeltaTableReadCommitVersion(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*Metdata)
+	_, ok = actions[2].(*Metadata)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}
@@ -182,7 +182,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*Metdata)
+	_, ok = actions[2].(*Metadata)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}

--- a/delta_test.go
+++ b/delta_test.go
@@ -52,11 +52,11 @@ func TestDeltaTransactionPrepareCommit(t *testing.T) {
 	var store filestore.FileObjectStore
 	store.SetBaseURI(storage.NewPath("tmp/"))
 	l := filelock.New(storage.NewPath(""), "tmp/_delta_log/_commit.lock", filelock.Options{})
-	deltaTable := DeltaTable{Store: &store, LockClient: l}
-	options := DeltaTransactionOptions{MaxRetryCommitAttempts: 3}
+	deltaTable := Table{Store: &store, LockClient: l}
+	options := TransactionOptions{MaxRetryCommitAttempts: 3}
 	os.MkdirAll("tmp/_delta_log/", 0700)
 	defer os.RemoveAll("tmp/_delta_log/")
-	transaction := NewDeltaTransaction(&deltaTable, &options)
+	transaction := NewTransaction(&deltaTable, &options)
 	add := Add{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
 		Size:             984,
@@ -92,7 +92,7 @@ func TestDeltaTransactionPrepareCommit(t *testing.T) {
 
 func TestDeltaTableReadCommitVersion(t *testing.T) {
 	table, _, _ := setupTest(t)
-	table.Create(DeltaTableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestDeltaTableReadCommitVersion(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*MetaData)
+	_, ok = actions[2].(*Metdata)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}
@@ -139,7 +139,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	format := new(Format).Default()
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
-	metadata := NewDeltaTableMetaData("Test Table", "", format, schema, []string{}, config)
+	metadata := NewTableMetadata("Test Table", "", format, schema, []string{}, config)
 	protocol := new(Protocol).Default()
 	stats := Stats{NumRecords: 1, MinValues: map[string]any{"first_column": 1}}
 	path := "part-123.snappy.parquet"
@@ -182,7 +182,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 	if !ok {
 		t.Error("Expected Protocol for second action")
 	}
-	_, ok = actions[2].(*MetaData)
+	_, ok = actions[2].(*Metdata)
 	if !ok {
 		t.Error("Expected MetaData for third action")
 	}
@@ -208,7 +208,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 
 func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	table, _, _ := setupTest(t)
-	table.Create(DeltaTableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -218,8 +218,8 @@ func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if transaction.DeltaTable.State.Version != 1 {
-		t.Errorf("want version = 1,has version = %d", transaction.DeltaTable.State.Version)
+	if transaction.Table.State.Version != 1 {
+		t.Errorf("want version = 1,has version = %d", transaction.Table.State.Version)
 	}
 
 	//try again with the same version
@@ -227,8 +227,8 @@ func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	if !errors.Is(err, storage.ErrObjectDoesNotExist) {
 		t.Error(err)
 	}
-	if transaction.DeltaTable.State.Version != 2 {
-		t.Errorf("want version = 1,has version = %d", transaction.DeltaTable.State.Version)
+	if transaction.Table.State.Version != 2 {
+		t.Errorf("want version = 1,has version = %d", transaction.Table.State.Version)
 	}
 
 	//prpare a new commit and try on the next version
@@ -237,8 +237,8 @@ func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if transaction.DeltaTable.State.Version != 3 {
-		t.Errorf("want version = 2,has version = %d", transaction.DeltaTable.State.Version)
+	if transaction.Table.State.Version != 3 {
+		t.Errorf("want version = 2,has version = %d", transaction.Table.State.Version)
 	}
 
 }
@@ -259,9 +259,9 @@ func TestTryCommitWithExistingLock(t *testing.T) {
 	store := filestore.New(tmpPath)
 	state := filestate.New(tmpPath, "_delta_log/_commit.state")
 
-	table := NewDeltaTable(store, lockClient, state)
+	table := NewTable(store, lockClient, state)
 
-	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{MaxRetryCommitAttempts: 3})
+	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 3})
 	version, err := transaction.Commit(operation, appMetaData)
 	if !errors.Is(err, ErrExceededCommitRetryAttempts) {
 		t.Error(err)
@@ -313,9 +313,9 @@ func TestCommitUnlockFailure(t *testing.T) {
 	store := filestore.New(tmpPath)
 	state := filestate.New(tmpPath, "_delta_log/_commit.state")
 
-	table := NewDeltaTable(store, &lockClient, state)
+	table := NewTable(store, &lockClient, state)
 
-	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{MaxRetryCommitAttempts: 3})
+	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 3})
 	_, err := transaction.Commit(operation, appMetaData)
 	if !errors.Is(err, lock.ErrUnableToUnlock) {
 		t.Error(err)
@@ -329,9 +329,9 @@ func TestTryCommitWithNilLockAndLocalState(t *testing.T) {
 	store := filestore.New(tmpPath)
 	storeState := localstate.New(-1)
 	lock := nillock.New()
-	table := NewDeltaTable(store, lock, storeState)
+	table := NewTable(store, lock, storeState)
 
-	table.Create(DeltaTableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
+	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
 	transaction, operation, appMetaData := setupTransaction(t, table, nil)
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
@@ -341,8 +341,8 @@ func TestTryCommitWithNilLockAndLocalState(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if transaction.DeltaTable.State.Version != 1 {
-		t.Errorf("want version %d, has version = %d", 1, transaction.DeltaTable.State.Version)
+	if transaction.Table.State.Version != 1 {
+		t.Errorf("want version %d, has version = %d", 1, transaction.Table.State.Version)
 	}
 
 	commit, _ = transaction.PrepareCommit(operation, appMetaData)
@@ -350,8 +350,8 @@ func TestTryCommitWithNilLockAndLocalState(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if transaction.DeltaTable.State.Version != 2 {
-		t.Errorf("want version %d, has version = %d", 2, transaction.DeltaTable.State.Version)
+	if transaction.Table.State.Version != 2 {
+		t.Errorf("want version %d, has version = %d", 2, transaction.Table.State.Version)
 	}
 }
 
@@ -369,7 +369,7 @@ func TestDeltaTableCreate(t *testing.T) {
 	format := new(Format).Default()
 	config := make(map[string]string)
 	config[string(AppendOnlyDeltaConfigKey)] = "true"
-	metadata := NewDeltaTableMetaData("Test Table", "", format, schema, []string{}, config)
+	metadata := NewTableMetadata("Test Table", "", format, schema, []string{}, config)
 	protocol := new(Protocol).Default()
 	add := Add{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
@@ -405,7 +405,7 @@ func TestDeltaTableExists(t *testing.T) {
 	if tableExists {
 		t.Errorf("table should not exist")
 	}
-	metadata := NewDeltaTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 
 	err = table.Create(*metadata, Protocol{}, make(map[string]any), []Add{})
 	if err != nil {
@@ -441,7 +441,7 @@ func TestDeltaTableExists(t *testing.T) {
 		t.Error(err)
 	}
 	// Delete original version file
-	commitPath := filepath.Join(tmpDir, CommitUriFromVersion(0).Raw)
+	commitPath := filepath.Join(tmpDir, CommitURIFromVersion(0).Raw)
 	err = os.Remove(commitPath)
 	if err != nil {
 		t.Error(err)
@@ -458,7 +458,7 @@ func TestDeltaTableExists(t *testing.T) {
 	}
 
 	// Move the new version file to a backup folder that starts with _delta_log
-	commitPath = filepath.Join(tmpDir, CommitUriFromVersion(1).Raw)
+	commitPath = filepath.Join(tmpDir, CommitURIFromVersion(1).Raw)
 	os.MkdirAll(filepath.Join(tmpDir, "_delta_log.bak"), 0700)
 	fakeCommitPath := filepath.Join(tmpDir, "_delta_log.bak/00000000000000000000.json")
 	err = os.Rename(commitPath, fakeCommitPath)
@@ -511,9 +511,9 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 	tmpPath := storage.NewPath(tmpDir)
 	state := filestate.New(tmpPath, "_delta_log/_commit.state")
 	lock := filelock.New(tmpPath, "_delta_log/_commit.lock", filelock.Options{})
-	table := NewDeltaTable(s3Store, lock, state)
+	table := NewTable(s3Store, lock, state)
 
-	metadata := NewDeltaTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 
 	err = table.Create(*metadata, Protocol{}, make(map[string]any), []Add{})
 	if err != nil {
@@ -530,7 +530,7 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 		t.Error(err)
 	}
 	// Delete original version file
-	err = s3Store.Delete(CommitUriFromVersion(0))
+	err = s3Store.Delete(CommitURIFromVersion(0))
 	if err != nil {
 		t.Error(err)
 	}
@@ -562,7 +562,7 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 func TestDeltaTableTryCommitLoop(t *testing.T) {
 	table, _, _ := setupTest(t)
 
-	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{})
+	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{})
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
 		t.Error(err)
@@ -586,8 +586,8 @@ func TestDeltaTableTryCommitLoop(t *testing.T) {
 
 func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
-	table.Create(DeltaTableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{MaxRetryCommitAttempts: 5, RetryWaitDuration: time.Second})
+	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 5, RetryWaitDuration: time.Second})
 	commit, err := transaction.PrepareCommit(operation, appMetaData)
 	if err != nil {
 		t.Error(err)
@@ -599,11 +599,11 @@ func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 	}
 
 	//Some other process writes commit 0002.json
-	fakeCommit2 := filepath.Join(tmpDir, CommitUriFromVersion(2).Raw)
+	fakeCommit2 := filepath.Join(tmpDir, CommitURIFromVersion(2).Raw)
 	os.WriteFile(fakeCommit2, []byte("temp commit data"), 0700)
 
 	//Some other process writes commit 0003.json
-	fakeCommit3 := filepath.Join(tmpDir, CommitUriFromVersion(3).Raw)
+	fakeCommit3 := filepath.Join(tmpDir, CommitURIFromVersion(3).Raw)
 	os.WriteFile(fakeCommit3, []byte("temp commit data"), 0700)
 
 	//create the next commit, should be 004.json after trying 003.json
@@ -627,16 +627,16 @@ func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 		t.Errorf("want table.State.Version=4, has %d", table.State.Version)
 	}
 
-	if !fileExists(filepath.Join(tmpDir, CommitUriFromVersion(4).Raw)) {
-		t.Errorf("File %s should exist", CommitUriFromVersion(4).Raw)
+	if !fileExists(filepath.Join(tmpDir, CommitURIFromVersion(4).Raw)) {
+		t.Errorf("File %s should exist", CommitURIFromVersion(4).Raw)
 	}
 
 }
 
 func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
-	table.Create(DeltaTableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction, operation, appMetaData := setupTransaction(t, table, &DeltaTransactionOptions{
+	table.Create(TableMetadata{}, Protocol{}, CommitInfo{}, []Add{})
+	transaction, operation, appMetaData := setupTransaction(t, table, &TransactionOptions{
 		MaxRetryCommitAttempts:                5, //Should break on max attempts if the latest version logic fails
 		RetryWaitDuration:                     time.Second,
 		RetryCommitAttemptsBeforeLoadingTable: 2, //Should get the latest version after 2 attempts
@@ -681,8 +681,8 @@ func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 		t.Errorf("want table.State.Version=10, has %d", table.State.Version)
 	}
 
-	if !fileExists(filepath.Join(tmpDir, CommitUriFromVersion(10).Raw)) {
-		t.Errorf("File %s should exist", CommitUriFromVersion(10).Raw)
+	if !fileExists(filepath.Join(tmpDir, CommitURIFromVersion(10).Raw)) {
+		t.Errorf("File %s should exist", CommitURIFromVersion(10).Raw)
 	}
 
 	// Test SyncStateStore by putting the state store out of sync
@@ -701,7 +701,7 @@ func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 func TestCommitConcurrent(t *testing.T) {
 	// log.SetLevel(log.DebugLevel)
 	table, state, tmpDir := setupTest(t)
-	metadata := NewDeltaTableMetaData("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
+	metadata := NewTableMetadata("Test Table", "", new(Format).Default(), SchemaTypeStruct{}, []string{}, make(map[string]string))
 	err := table.Create(*metadata, Protocol{}, CommitInfo{}, []Add{})
 	if err != nil {
 		t.Error(err)
@@ -725,8 +725,8 @@ func TestCommitConcurrent(t *testing.T) {
 			lock := filelock.New(storage.NewPath(tmpDir), "_delta_log/_commit.lock", filelock.Options{Block: true})
 
 			//Lock needs to be instantiated for each worker because it is passed by reference, so if it is not created different instances of tables would share the same lock
-			table := NewDeltaTable(store, lock, state)
-			transaction, operation, appMetaData := setupTransaction(t, table, NewDeltaTransactionOptions())
+			table := NewTable(store, lock, state)
+			transaction, operation, appMetaData := setupTransaction(t, table, NewTransactionOptions())
 			_, err := transaction.Commit(operation, appMetaData)
 			if err != nil {
 				errs <- err
@@ -753,7 +753,7 @@ func TestCommitConcurrent(t *testing.T) {
 		t.Errorf("Final Version in lock should be 100")
 	}
 
-	lastCommitFile := filepath.Join(tmpDir, CommitUriFromVersion(100).Raw)
+	lastCommitFile := filepath.Join(tmpDir, CommitURIFromVersion(100).Raw)
 	if !fileExists(lastCommitFile) {
 		t.Errorf("File should exist")
 	}
@@ -784,7 +784,7 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 		PartitionValues:  make(map[string]string),
 	}
 
-	metadata := NewDeltaTableMetaData("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
+	metadata := NewTableMetadata("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
 	err = table.Create(*metadata, new(Protocol).Default(), CommitInfo{}, []Add{add})
 	if err != nil {
 		t.Error(err)
@@ -808,8 +808,8 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 			lock := filelock.New(storage.NewPath(tmpDir), "_delta_log/_commit.lock", filelock.Options{Block: true})
 
 			//Lock needs to be instantiated for each worker because it is passed by reference, so if it is not created different instances of tables would share the same lock
-			table := NewDeltaTable(store, lock, state)
-			transaction := table.CreateTransaction(NewDeltaTransactionOptions())
+			table := NewTable(store, lock, state)
+			transaction := table.CreateTransaction(NewTransactionOptions())
 
 			//Make some data
 			data := makeTestData(rand.Intn(50))
@@ -861,7 +861,7 @@ func TestCommitConcurrentWithParquet(t *testing.T) {
 		t.Errorf("Final Version in lock should be 100")
 	}
 
-	lastCommitFile := filepath.Join(tmpDir, CommitUriFromVersion(100).Raw)
+	lastCommitFile := filepath.Join(tmpDir, CommitURIFromVersion(100).Raw)
 	if !fileExists(lastCommitFile) {
 		t.Errorf("File should exist")
 	}
@@ -892,7 +892,7 @@ func TestCreateWithParquet(t *testing.T) {
 		PartitionValues:  make(map[string]string),
 	}
 
-	metadata := NewDeltaTableMetaData("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
+	metadata := NewTableMetadata("Test Table", "test description", new(Format).Default(), schema, []string{}, make(map[string]string))
 	err = table.Create(*metadata, new(Protocol).Default(), CommitInfo{}, []Add{add})
 	if err != nil {
 		t.Error(err)
@@ -1029,7 +1029,7 @@ func writeParquet[T any](data []T, filename string) (*payload, error) {
 }
 
 // / Helper function to set up test state
-func setupTest(t *testing.T) (table *DeltaTable, state *filestate.FileStateStore, tmpDir string) {
+func setupTest(t *testing.T) (table *Table, state *filestate.FileStateStore, tmpDir string) {
 	t.Helper()
 
 	tmpDir = t.TempDir()
@@ -1037,12 +1037,12 @@ func setupTest(t *testing.T) (table *DeltaTable, state *filestate.FileStateStore
 	store := filestore.New(tmpPath)
 	state = filestate.New(tmpPath, "_delta_log/_commit.state")
 	lock := filelock.New(tmpPath, "_delta_log/_commit.lock", filelock.Options{})
-	table = NewDeltaTable(store, lock, state)
+	table = NewTable(store, lock, state)
 	return
 }
 
 // / Helper function to set up a basic transaction
-func setupTransaction(t *testing.T, table *DeltaTable, options *DeltaTransactionOptions) (transaction *DeltaTransaction, operation DeltaOperation, appMetaData map[string]any) {
+func setupTransaction(t *testing.T, table *Table, options *TransactionOptions) (transaction *Transaction, operation Operation, appMetaData map[string]any) {
 	t.Helper()
 
 	transaction = table.CreateTransaction(options)
@@ -1066,7 +1066,7 @@ func fileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-func TestCommitUriFromVersion(t *testing.T) {
+func TestCommitURIFromVersion(t *testing.T) {
 	type test struct {
 		input int64
 		want  string
@@ -1081,7 +1081,7 @@ func TestCommitUriFromVersion(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := CommitUriFromVersion(tc.input)
+		got := CommitURIFromVersion(tc.input)
 		if got.Raw != tc.want {
 			t.Errorf("expected %s, got %s", tc.want, got)
 		}
@@ -1103,7 +1103,7 @@ func TestIsValidCommitUri(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := IsValidCommitUri(storage.NewPath(tc.input))
+		got := IsValidCommitURI(storage.NewPath(tc.input))
 		if got != tc.want {
 			t.Errorf("expected %t, got %t", tc.want, got)
 		}
@@ -1126,7 +1126,7 @@ func TestCommitVersionFromUri(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		match, got := CommitVersionFromUri(storage.NewPath(tc.input))
+		match, got := CommitVersionFromURI(storage.NewPath(tc.input))
 		if match != tc.wantMatch {
 			t.Errorf("expected %t, got %t", tc.wantMatch, match)
 		}
@@ -1155,7 +1155,7 @@ func TestCommitOrCheckpointVersionFromUri(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		match, got := CommitOrCheckpointVersionFromUri(storage.NewPath(tc.input))
+		match, got := CommitOrCheckpointVersionFromURI(storage.NewPath(tc.input))
 		if match != tc.wantMatch {
 			t.Errorf("expected %t, got %t", tc.wantMatch, match)
 		}
@@ -1184,8 +1184,8 @@ func TestLatestVersion(t *testing.T) {
 		path     = storage.NewPath(dir)
 		state    = filestate.New(path, "_delta_log/_commit.state")
 		lock     = filelock.New(path, "_delta_log/_commit.lock", filelock.Options{})
-		table    = NewDeltaTable(store, lock, state)
-		metadata = NewDeltaTableMetaData("test", "", new(Format).Default(), SchemaTypeStruct{}, nil, make(map[string]string))
+		table    = NewTable(store, lock, state)
+		metadata = NewTableMetadata("test", "", new(Format).Default(), SchemaTypeStruct{}, nil, make(map[string]string))
 	)
 
 	if _, err := table.LatestVersion(); !errors.Is(err, ErrNotATable) { // if NO error
@@ -1248,7 +1248,7 @@ func TestLatestVersion(t *testing.T) {
 	}
 
 	for version := 2; version < 2100; version++ {
-		filePath := CommitUriFromVersion(int64(version))
+		filePath := CommitURIFromVersion(int64(version))
 
 		table.Store.Put(filePath, nil)
 	}
@@ -1277,7 +1277,7 @@ func TestLatestVersion(t *testing.T) {
 	}
 
 	for version := 0; version < 1000; version++ {
-		filePath := CommitUriFromVersion(int64(version))
+		filePath := CommitURIFromVersion(int64(version))
 
 		table.Store.Delete(filePath)
 	}
@@ -1291,7 +1291,7 @@ func TestLatestVersion(t *testing.T) {
 	}
 
 	for version := 2100; version < 4100; version++ {
-		filePath := CommitUriFromVersion(int64(version))
+		filePath := CommitURIFromVersion(int64(version))
 
 		table.Store.Put(filePath, nil)
 	}
@@ -1348,11 +1348,11 @@ func BenchmarkLatestVersion(b *testing.B) {
 	var (
 		state = filestate.New(path, "_delta_log/_commit.state")
 		lock  = filelock.New(path, "_delta_log/_commit.lock", filelock.Options{})
-		table = NewDeltaTable(s3Store, lock, state)
+		table = NewTable(s3Store, lock, state)
 	)
 
 	for version := 0; version < 1000; version++ {
-		filePath := CommitUriFromVersion(int64(version))
+		filePath := CommitURIFromVersion(int64(version))
 
 		table.Store.Put(filePath, nil)
 	}
@@ -1365,7 +1365,7 @@ func TestLoadVersion(t *testing.T) {
 	store, stateStore, lock, _ := setupCheckpointTest(t, "testdata/checkpoints/simple")
 
 	// Load version 2
-	table := NewDeltaTable(store, lock, stateStore)
+	table := NewTable(store, lock, stateStore)
 	var version int64 = 2
 	err := table.LoadVersion(&version)
 	if err != nil {
@@ -1426,7 +1426,7 @@ func TestLoadVersion(t *testing.T) {
 	}
 	provider := "parquet"
 	options := map[string]string{}
-	expectedState.CurrentMetadata = NewDeltaTableMetaData("", "", Format{Provider: provider, Options: options}, schema, []string{"date"}, make(map[string]string))
+	expectedState.CurrentMetadata = NewTableMetadata("", "", Format{Provider: provider, Options: options}, schema, []string{"date"}, make(map[string]string))
 	expectedState.CurrentMetadata.CreatedTime = time.Unix(1627668675, 432000000)
 	expectedState.CurrentMetadata.Id = uuid.MustParse("853536c9-0abe-4e66-9732-1718e542e6aa")
 
@@ -1452,7 +1452,7 @@ func TestLoadVersion(t *testing.T) {
 }
 
 // Performs common setup for the log store tests, creating a Delta table backed by mock DynamoDB and S3 clients
-func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, table *DeltaTable, transaction *DeltaTransaction) {
+func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, table *Table, transaction *Transaction) {
 	t.Helper()
 
 	logStoreTableName = "version_log_store"
@@ -1477,7 +1477,7 @@ func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, tab
 		t.Errorf("Failed to create lock: %v", err)
 	}
 
-	table = NewDeltaTableWithLogStore(store, lock, logStore)
+	table = NewTableWithLogStore(store, lock, logStore)
 
 	schema := SchemaTypeStruct{
 		Fields: []SchemaField{
@@ -1486,7 +1486,7 @@ func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, tab
 		}}
 
 	config := make(map[string]string)
-	metadata := NewDeltaTableMetaData(
+	metadata := NewTableMetadata(
 		"test",
 		"This is a test table.",
 		new(Format).Default(),
@@ -1513,7 +1513,7 @@ func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, tab
 	appMetaData := make(map[string]any)
 	appMetaData["isBlindAppend"] = true
 
-	transaction = table.CreateTransaction(NewDeltaTransactionOptions())
+	transaction = table.CreateTransaction(NewTransactionOptions())
 	transaction.AddActions(actions)
 	transaction.SetOperation(operation)
 	transaction.SetAppMetadata(appMetaData)
@@ -1543,7 +1543,7 @@ func TestCommitLogStore_Sequential(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(items); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -1580,7 +1580,7 @@ func TestCommitLogStore_Sequential(t *testing.T) {
 	logs := objects.Objects[1 : len(objects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -1687,7 +1687,7 @@ func TestCommitLogStore_LimitedConcurrent(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(items); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -1720,7 +1720,7 @@ func TestCommitLogStore_LimitedConcurrent(t *testing.T) {
 	logs := objects.Objects[len(objects.Objects)-transactions-1 : len(objects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -1823,7 +1823,7 @@ func TestCommitLogStore_UnlimitedConcurrent(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(items); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", items[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -1856,7 +1856,7 @@ func TestCommitLogStore_UnlimitedConcurrent(t *testing.T) {
 	logs := objects.Objects[len(objects.Objects)-transactions-1 : len(objects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -1928,7 +1928,7 @@ func TestCommitLogStore_UnlimitedConcurrent(t *testing.T) {
 }
 
 // Performs common setup for the log store tests, creating a Delta table backed by mock DynamoDB and S3 clients
-func setUpMultiClusterLogStoreTest(t *testing.T) (logStoreTableName string, firstTable *DeltaTable, secondTable *DeltaTable, actions []Action, operation Write, appMetadata map[string]any) {
+func setUpMultiClusterLogStoreTest(t *testing.T) (logStoreTableName string, firstTable *Table, secondTable *Table, actions []Action, operation Write, appMetadata map[string]any) {
 	t.Helper()
 
 	logStoreTableName = "version_log_store"
@@ -1950,8 +1950,8 @@ func setUpMultiClusterLogStoreTest(t *testing.T) (logStoreTableName string, firs
 	firstLock := nillock.New()
 	secondLock := nillock.New()
 
-	firstTable = NewDeltaTableWithLogStore(store, firstLock, logStore)
-	secondTable = NewDeltaTableWithLogStore(store, secondLock, logStore)
+	firstTable = NewTableWithLogStore(store, firstLock, logStore)
+	secondTable = NewTableWithLogStore(store, secondLock, logStore)
 
 	actions = []Action{Add{
 		Path:             "part-00000-b08cb562-b392-441d-a090-494a47da752b-c000.snappy.parquet",
@@ -1977,14 +1977,14 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	var (
 		wg                sync.WaitGroup
 		transactions      = 500
-		firstTransaction  *DeltaTransaction
-		secondTransaction *DeltaTransaction
+		firstTransaction  *Transaction
+		secondTransaction *Transaction
 	)
 	for i := 1; i < transactions/2+1; i++ {
 		wg.Add(1)
 
 		go func() {
-			firstTransaction = firstTable.CreateTransaction(NewDeltaTransactionOptions())
+			firstTransaction = firstTable.CreateTransaction(NewTransactionOptions())
 			firstTransaction.AddActions(actions)
 			firstTransaction.SetOperation(operation)
 			firstTransaction.SetAppMetadata(appMetadata)
@@ -1995,7 +1995,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 			}
 			t.Logf("Committed version %d", version)
 
-			secondTransaction = secondTable.CreateTransaction(NewDeltaTransactionOptions())
+			secondTransaction = secondTable.CreateTransaction(NewTransactionOptions())
 			secondTransaction.AddActions(actions)
 			secondTransaction.SetOperation(operation)
 			secondTransaction.SetAppMetadata(appMetadata)
@@ -2021,7 +2021,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(firstItems); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(firstItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Failed to parse version from %s", storage.NewPath(firstItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value).Raw)
@@ -2054,7 +2054,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	logs := firstObjects.Objects[len(firstObjects.Objects)-transactions-1 : len(firstObjects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("First table: failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -2139,7 +2139,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(secondItems); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(secondItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Second table: failed to parse version from %s", secondItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -2176,7 +2176,7 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	logs = secondObjects.Objects[len(secondObjects.Objects)-transactions-1 : len(secondObjects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("Second table: failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -2253,7 +2253,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 
 	versions := 1000
 	for version := 1; version < versions; version++ {
-		filePath := CommitUriFromVersion(int64(version))
+		filePath := CommitURIFromVersion(int64(version))
 
 		err := firstTable.Store.Put(filePath, nil)
 		if err != nil {
@@ -2264,14 +2264,14 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	var (
 		wg                sync.WaitGroup
 		transactions      = 500
-		firstTransaction  *DeltaTransaction
-		secondTransaction *DeltaTransaction
+		firstTransaction  *Transaction
+		secondTransaction *Transaction
 	)
 	for i := 1; i < transactions/2+1; i++ {
 		wg.Add(1)
 
 		go func() {
-			firstTransaction = firstTable.CreateTransaction(NewDeltaTransactionOptions())
+			firstTransaction = firstTable.CreateTransaction(NewTransactionOptions())
 			firstTransaction.AddActions(actions)
 			firstTransaction.SetOperation(operation)
 			firstTransaction.SetAppMetadata(appMetadata)
@@ -2282,7 +2282,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 			}
 			t.Logf("Committed version %d", version)
 
-			secondTransaction = secondTable.CreateTransaction(NewDeltaTransactionOptions())
+			secondTransaction = secondTable.CreateTransaction(NewTransactionOptions())
 			secondTransaction.AddActions(actions)
 			secondTransaction.SetOperation(operation)
 			secondTransaction.SetAppMetadata(appMetadata)
@@ -2308,7 +2308,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(firstItems); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(firstItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("First table: failed to parse version from %s", firstItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -2341,7 +2341,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	logs := firstObjects.Objects[len(firstObjects.Objects)-transactions-1 : len(firstObjects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("First table: failed to parse version from %s", logs[log].Location.Raw)
 		}
@@ -2426,7 +2426,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	}
 
 	for entry := 0; entry < len(secondItems); entry++ {
-		parsed, version := CommitVersionFromUri(
+		parsed, version := CommitVersionFromURI(
 			storage.NewPath(secondItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value))
 		if !parsed {
 			t.Errorf("Second table: failed to parse version from %s", secondItems[entry][string(dynamodblogstore.FileName)].(*types.AttributeValueMemberS).Value)
@@ -2463,7 +2463,7 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	logs = secondObjects.Objects[len(secondObjects.Objects)-transactions-1 : len(secondObjects.Objects)-1]
 
 	for log := 0; log < len(logs); log++ {
-		parsed, version := CommitVersionFromUri(logs[log].Location)
+		parsed, version := CommitVersionFromURI(logs[log].Location)
 		if !parsed {
 			t.Errorf("Second table: failed to parse version from %s", logs[log].Location.Raw)
 		}

--- a/schema.go
+++ b/schema.go
@@ -24,10 +24,10 @@ import (
 // / Type alias for a string expected to match a GUID/UUID format
 type Guid string
 
-// Represents the schema of the delta table.
+// Represents the schema of the Delta table.
 type Schema = SchemaTypeStruct
 
-// Represents the schema of the delta table.
+// Represents the schema of the Delta table.
 type SchemaTypeStruct struct {
 	Fields []SchemaField //`json:"fields"`
 }

--- a/tablestate.go
+++ b/tablestate.go
@@ -525,7 +525,7 @@ func checkpointRows(
 
 	// Row 2: metadata
 	if startOffset <= currentOffset && len(checkpointRows) < config.MaxRowsPerPart {
-		metadata := tableState.CurrentMetadata.ToMetadata()
+		metadata := tableState.CurrentMetadata.ToMetaData()
 		checkpointRows = append(checkpointRows, CheckpointEntry{MetaData: &metadata})
 	}
 

--- a/tablestate.go
+++ b/tablestate.go
@@ -145,7 +145,7 @@ func (tableState *TableState) processAction(actionInterface Action) error {
 	case *Remove:
 		// TODO - do we need to decode as in delta-rs?
 		tableState.Tombstones[action.Path] = *action
-	case *Metdata:
+	case *Metadata:
 		if action.Configuration != nil {
 			// Parse the configuration options that we make use of
 			option, ok := action.Configuration[string(DeletedFileRetentionDurationDeltaConfigKey)]

--- a/tablestate.go
+++ b/tablestate.go
@@ -41,7 +41,7 @@ type TableState struct {
 	// current table version represented by this table state
 	Version int64
 	// A remove action should remain in the state of the table as a tombstone until it has expired.
-	// A tombstone expires when the creation timestamp of the delta file exceeds the expiration
+	// A tombstone expires when the creation timestamp of the Delta file exceeds the expiration
 	// This is empty if on-disk optimization is enabled
 	Tombstones map[string]Remove
 	// Active files for table state
@@ -53,7 +53,7 @@ type TableState struct {
 	MinReaderVersion      int32
 	MinWriterVersion      int32
 	// Table metadata corresponding to current version
-	CurrentMetadata *DeltaTableMetaData
+	CurrentMetadata *TableMetadata
 	// Retention period for tombstones as time.Duration (nanoseconds)
 	TombstoneRetention time.Duration
 	// Retention period for log entries as time.Duration (nanoseconds)
@@ -117,7 +117,7 @@ func (tableState *TableState) TombstoneCount() int {
 }
 
 // NewTableStateFromCommit reads a specific commit version and returns the contained TableState
-func NewTableStateFromCommit(table *DeltaTable, version int64) (*TableState, error) {
+func NewTableStateFromCommit(table *Table, version int64) (*TableState, error) {
 	actions, err := table.ReadCommitVersion(version)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ func (tableState *TableState) processAction(actionInterface Action) error {
 	case *Remove:
 		// TODO - do we need to decode as in delta-rs?
 		tableState.Tombstones[action.Path] = *action
-	case *MetaData:
+	case *Metdata:
 		if action.Configuration != nil {
 			// Parse the configuration options that we make use of
 			option, ok := action.Configuration[string(DeletedFileRetentionDurationDeltaConfigKey)]
@@ -173,7 +173,7 @@ func (tableState *TableState) processAction(actionInterface Action) error {
 				tableState.ExperimentalEnableExpiredLogCleanup = boolOption
 			}
 		}
-		deltaTableMetadata, err := action.ToDeltaTableMetaData()
+		deltaTableMetadata, err := action.ToTableMetadata()
 		if err != nil {
 			return err
 		}
@@ -247,7 +247,7 @@ func (tableState *TableState) merge(newTableState *TableState, maxRowsPerPart in
 	return nil
 }
 
-func stateFromCheckpoint(table *DeltaTable, checkpoint *CheckPoint, config *OptimizeCheckpointConfiguration) (*TableState, error) {
+func stateFromCheckpoint(table *Table, checkpoint *CheckPoint, config *OptimizeCheckpointConfiguration) (*TableState, error) {
 	newState := NewTableState(checkpoint.Version)
 	checkpointDataPaths := table.GetCheckpointDataPaths(checkpoint)
 
@@ -525,7 +525,7 @@ func checkpointRows(
 
 	// Row 2: metadata
 	if startOffset <= currentOffset && len(checkpointRows) < config.MaxRowsPerPart {
-		metadata := tableState.CurrentMetadata.ToMetaData()
+		metadata := tableState.CurrentMetadata.ToMetadata()
 		checkpointRows = append(checkpointRows, CheckpointEntry{MetaData: &metadata})
 	}
 

--- a/tablestate.go
+++ b/tablestate.go
@@ -53,7 +53,7 @@ type TableState struct {
 	MinReaderVersion      int32
 	MinWriterVersion      int32
 	// Table metadata corresponding to current version
-	CurrentMetadata *TableMetadata
+	CurrentMetadata *TableMetaData
 	// Retention period for tombstones as time.Duration (nanoseconds)
 	TombstoneRetention time.Duration
 	// Retention period for log entries as time.Duration (nanoseconds)
@@ -145,7 +145,7 @@ func (tableState *TableState) processAction(actionInterface Action) error {
 	case *Remove:
 		// TODO - do we need to decode as in delta-rs?
 		tableState.Tombstones[action.Path] = *action
-	case *Metadata:
+	case *MetaData:
 		if action.Configuration != nil {
 			// Parse the configuration options that we make use of
 			option, ok := action.Configuration[string(DeletedFileRetentionDurationDeltaConfigKey)]


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Many of the function and variable names in the `delta` package have the word "Delta" in them. Since these functions and variables are already scoped to the `delta` package, removing "Delta" from their names would improve clarity.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
