### PR TITLE
Make DoesCheckpointVersionExist() public

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -160,8 +160,8 @@ func checkpointInfoFromURI(path storage.Path) (checkpoint *CheckPoint, part int3
 	return
 }
 
-// / Check whether the given checkpoint version exists, either as a single- or multi-part checkpoint
-func doesCheckpointVersionExist(store storage.ObjectStore, version int64, validateAllPartsExist bool) (bool, error) {
+// DoesCheckpointVersionExist returns true if the given checkpoint version exists, either as a single- or multi-part checkpoint
+func DoesCheckpointVersionExist(store storage.ObjectStore, version int64, validateAllPartsExist bool) (bool, error) {
 	// List all files starting with the version prefix.  This will also find commit logs and possible crc files
 	str := fmt.Sprintf("%020d", version)
 	path := storage.PathFromIter([]string{"_delta_log", str})
@@ -208,7 +208,7 @@ func doesCheckpointVersionExist(store storage.ObjectStore, version int64, valida
 // / Assumes that checkpointing is locked such that no other process is currently trying to write a checkpoint for the same version
 // / Applies tombstone expiration first
 func createCheckpointFor(tableState *TableState, store storage.ObjectStore, checkpointConfiguration *CheckpointConfiguration) error {
-	checkpointExists, err := doesCheckpointVersionExist(store, tableState.Version, false)
+	checkpointExists, err := DoesCheckpointVersionExist(store, tableState.Version, false)
 	if err != nil {
 		return err
 	}

--- a/delta_test.go
+++ b/delta_test.go
@@ -1116,6 +1116,8 @@ func TestIsValidCommitUri(t *testing.T) {
 		{input: "_delta_log/00000000000000000000.json", want: true},
 		{input: "_delta_log/00000000000000000001.json", want: true},
 		{input: "_delta_log/01234567890123456789.json", want: true},
+		{input: "_delta_log/tmp_00000000000000000001.json", want: false},
+		{input: "_delta_log/00000000000000000001.json.tmp", want: false},
 		{input: "_delta_log/00000000000000000001.checkpoint.parquet", want: false},
 		{input: "_delta_log/_commit_aabbccdd-eeff-1122-3344-556677889900.json.tmp", want: false},
 	}
@@ -1165,21 +1167,28 @@ func TestCommitOrCheckpointVersionFromUri(t *testing.T) {
 
 	tests := []test{
 		{input: "_delta_log/00000000000000000000.json", wantMatch: true, wantVersion: 0},
+		{input: "_delta_log/tmp_00000000000000000000.json", wantMatch: false},
+		{input: "_delta_log/00000000000000000000.json.tmp", wantMatch: false},
 		{input: "_delta_log/00000000000000000001.json", wantMatch: true, wantVersion: 1},
 		{input: "_delta_log/01234567890123456789.json", wantMatch: true, wantVersion: 1234567890123456789},
 		{input: "_delta_log/00000000000000000001.checkpoint.parquet", wantMatch: true, wantVersion: 1},
 		{input: "_delta_log/00000000000000094451.checkpoint.0000000002.0000000061.parquet", wantMatch: true, wantVersion: 94451},
 		{input: "_delta_log/_commit_aabbccdd-eeff-1122-3344-556677889900.json.tmp", wantMatch: false},
+		{input: "_delta_log/tmp_00000000000000000001.checkpoint.parquet", wantMatch: false},
+		{input: "_delta_log/00000000000000000001.checkpoint.tmp.parquet", wantMatch: false},
+		{input: "_delta_log/00000000000000000001.checkpoint.parquet.tmp", wantMatch: false},
+		{input: "_delta_log/tmp_00000000000000094451.checkpoint.0000000002.0000000061.parquet", wantMatch: false},
+		{input: "_delta_log/00000000000000094451.checkpoint.0000000002.0000000061.parquet.tmp", wantMatch: false},
 	}
 
 	for _, tc := range tests {
 		match, got := CommitOrCheckpointVersionFromURI(storage.NewPath(tc.input))
 		if match != tc.wantMatch {
-			t.Errorf("expected %t, got %t", tc.wantMatch, match)
+			t.Errorf("expected %t, got %t for %s", tc.wantMatch, match, tc.input)
 		}
 		if match == tc.wantMatch && match {
 			if got != tc.wantVersion {
-				t.Errorf("expected %d, got %d", tc.wantVersion, got)
+				t.Errorf("expected %d, got %d for %s", tc.wantVersion, got, tc.input)
 			}
 		}
 	}


### PR DESCRIPTION
## Changes
- Make `DoesCheckpointVersionExist()` public so we can use it elsewhere
- Clean up the commit and checkpoint regular expressions; the named groups weren't being used so I've removed them, plus they weren't checking start and end of string everywhere so they were overly permissive.

## Tests
Expanded unit test cases

- [X] `make test` passing
- [ ] relevant integration tests passing
