### PR TITLE
Working folder cleanup

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -93,18 +93,14 @@ func NewCheckpointConfiguration() *CheckpointConfiguration {
 	return checkpointConfiguration
 }
 
-// NewOptimizeCheckpointConfigurationWithWorkingFolder returns a default enabled optimization configuration
+// NewOptimizeCheckpointConfiguration returns a default enabled optimization configuration
 // with a working folder in the table store's _delta_log/.tmp/ folder
 // but no concurrency enabled
-func NewOptimizeCheckpointConfigurationWithWorkingFolder(table *Table, version int64) (*OptimizeCheckpointConfiguration, error) {
+func NewOptimizeCheckpointConfiguration(table *Table, version int64) (*OptimizeCheckpointConfiguration, error) {
 	optimizeCheckpointConfiguration := new(OptimizeCheckpointConfiguration)
 	optimizeCheckpointConfiguration.OnDiskOptimization = true
 	optimizeCheckpointConfiguration.WorkingStore = table.Store
-	uuid, err := uuid.NewUUID()
-	if err != nil {
-		return nil, err
-	}
-	optimizeCheckpointConfiguration.WorkingFolder = storage.NewPath(fmt.Sprintf("_delta_log/.tmp/checkpoint-v%d-%s", version, uuid.String()))
+	optimizeCheckpointConfiguration.WorkingFolder = storage.NewPath(fmt.Sprintf("_delta_log/.tmp/checkpoint-v%d-%s", version, uuid.NewString()))
 	return optimizeCheckpointConfiguration, nil
 }
 

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/arrow/go/v13/parquet"
 	"github.com/apache/arrow/go/v13/parquet/compress"
 	"github.com/chelseajonesr/rfarrow"
+	"github.com/google/uuid"
 	"github.com/rivian/delta-go/storage"
 	"golang.org/x/sync/errgroup"
 )
@@ -71,6 +72,17 @@ type CheckpointConfiguration struct {
 	ReadWriteConfiguration OptimizeCheckpointConfiguration
 }
 
+// OptimizeCheckpointConfiguration holds settings for optimizing checkpoint read and write operations
+type OptimizeCheckpointConfiguration struct {
+	// Use an intermediate on-disk storage location to reduce memory
+	OnDiskOptimization bool
+	WorkingStore       storage.ObjectStore
+	WorkingFolder      storage.Path
+	// If these are > 1, checkpoint read and write operations will use this many goroutines
+	ConcurrentCheckpointRead  int
+	ConcurrentCheckpointWrite int
+}
+
 // NewCheckpointConfiguration returns the default configuration for creating checkpoints
 func NewCheckpointConfiguration() *CheckpointConfiguration {
 	checkpointConfiguration := new(CheckpointConfiguration)
@@ -79,6 +91,21 @@ func NewCheckpointConfiguration() *CheckpointConfiguration {
 	checkpointConfiguration.UnsafeIgnoreUnsupportedReaderWriterVersionErrors = false
 	checkpointConfiguration.DisableCleanup = false
 	return checkpointConfiguration
+}
+
+// NewOptimizeCheckpointConfigurationWithWorkingFolder returns a default enabled optimization configuration
+// with a working folder in the table store's _delta_log/.tmp/ folder
+// but no concurrency enabled
+func NewOptimizeCheckpointConfigurationWithWorkingFolder(table *Table, version int64) (*OptimizeCheckpointConfiguration, error) {
+	optimizeCheckpointConfiguration := new(OptimizeCheckpointConfiguration)
+	optimizeCheckpointConfiguration.OnDiskOptimization = true
+	optimizeCheckpointConfiguration.WorkingStore = table.Store
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, err
+	}
+	optimizeCheckpointConfiguration.WorkingFolder = storage.NewPath(fmt.Sprintf("_delta_log/.tmp/checkpoint-v%d-%s", version, uuid.String()))
+	return optimizeCheckpointConfiguration, nil
 }
 
 var (
@@ -94,8 +121,10 @@ var (
 	// ErrCheckpointAddZeroSize is returned if there is an Add action with size 0
 	// because including this would cause subsequent Optimize operations to fail.
 	ErrCheckpointAddZeroSize error = errors.New("zero size in add not allowed")
-	// ErrCheckpointEntryMultipleActions if a checkpoint entry has more than one non-null action
+	// ErrCheckpointEntryMultipleActions is returned if a checkpoint entry has more than one non-null action
 	ErrCheckpointEntryMultipleActions error = errors.New("checkpoint entry contains multiple actions")
+	// ErrWorkingFolder is returned if there is a problem with the optimization working folder
+	ErrCheckpointOptimizationWorkingFolder error = errors.New("error using checkpoint optimization working folder")
 )
 
 func checkpointFromBytes(bytes []byte) (*CheckPoint, error) {

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -100,7 +100,7 @@ func TestCheckpointInUseWorkingFolder(t *testing.T) {
 	store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "testdata/checkpoints/simple")
 	table := NewTable(store, lock, stateStore)
 	checkpointConfiguration := NewCheckpointConfiguration()
-	optimizeConfig, err := NewOptimizeCheckpointConfigurationWithWorkingFolder(table, 5)
+	optimizeConfig, err := NewOptimizeCheckpointConfiguration(table, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -96,6 +96,49 @@ func copyFilesToTempDirRecursively(t *testing.T, inputFolder string, outputFolde
 	return nil
 }
 
+func TestCheckpointInUseWorkingFolder(t *testing.T) {
+	store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "testdata/checkpoints/simple")
+	table := NewTable(store, lock, stateStore)
+	checkpointConfiguration := NewCheckpointConfiguration()
+	optimizeConfig, err := NewOptimizeCheckpointConfigurationWithWorkingFolder(table, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpointConfiguration.ReadWriteConfiguration = *optimizeConfig
+
+	tempFilePath := storage.NewPath(filepath.Join(optimizeConfig.WorkingFolder.Raw, "/test1.txt"))
+	err = store.Put(tempFilePath, []byte{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = CreateCheckpoint(store, checkpointLock, checkpointConfiguration, 5)
+	if !errors.Is(err, ErrCheckpointOptimizationWorkingFolder) {
+		t.Errorf("Expected error creating checkpoint with non-empty working folder, got %v", err)
+	}
+
+	// Remove the temp file and create the checkpoint
+	err = store.Delete(tempFilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = CreateCheckpoint(store, checkpointLock, checkpointConfiguration, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replace the temp file
+	err = store.Put(tempFilePath, []byte{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This CreateCheckpoint follows a different code path but should return the same error
+	_, err = CreateCheckpoint(store, checkpointLock, checkpointConfiguration, 10)
+	if !errors.Is(err, ErrCheckpointOptimizationWorkingFolder) {
+		t.Errorf("Expected error creating checkpoint with non-empty working folder, got %v", err)
+	}
+}
+
 func TestSimpleCheckpoint(t *testing.T) {
 	for _, useOnDisk := range []bool{false, true} {
 		for _, concurrent := range []int{0, 4} {
@@ -104,16 +147,19 @@ func TestSimpleCheckpoint(t *testing.T) {
 			if useOnDisk {
 				path := storage.NewPath("tempCheckpoint")
 				readConfig := OptimizeCheckpointConfiguration{OnDiskOptimization: true, WorkingStore: store, WorkingFolder: path}
-				defer store.Delete(path)
 				checkpointConfiguration.ReadWriteConfiguration = readConfig
 			}
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointRead = concurrent
 			checkpointConfiguration.ReadWriteConfiguration.ConcurrentCheckpointWrite = concurrent
 
 			// Create a checkpoint at version 5
-			_, err := CreateCheckpoint(store, checkpointLock, checkpointConfiguration, 5)
+			created, err := CreateCheckpoint(store, checkpointLock, checkpointConfiguration, 5)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if !created {
+				t.Fatal("Did not create checkpoint")
 			}
 
 			// Does the checkpoint exist


### PR DESCRIPTION
## Changes
Checkpoint working folder will be automatically cleaned up (all contents will be deleted).  If it's created by a `LoadTable...` or `OpenTable...` operation that is not called by `CreateCheckpoint`, it will be cleaned up before those return.  If it's created for `CreateCheckpoint` it will be used for both the state read and checkpoint write, and cleaned up after.

To avoid unhappy mistakes, on-disk optimization will return an error if the working folder is not initially empty.

Also adds function `NewOptimizeCheckpointConfiguration()` to set the working folder automatically to `_delta_log/.tmp/checkpoint-v<version>-<random uuid>`

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
