### PR TITLE
use store instead of table as parameter

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -96,10 +96,10 @@ func NewCheckpointConfiguration() *CheckpointConfiguration {
 // NewOptimizeCheckpointConfiguration returns a default enabled optimization configuration
 // with a working folder in the table store's _delta_log/.tmp/ folder
 // but no concurrency enabled
-func NewOptimizeCheckpointConfiguration(table *Table, version int64) (*OptimizeCheckpointConfiguration, error) {
+func NewOptimizeCheckpointConfiguration(store storage.ObjectStore, version int64) (*OptimizeCheckpointConfiguration, error) {
 	optimizeCheckpointConfiguration := new(OptimizeCheckpointConfiguration)
 	optimizeCheckpointConfiguration.OnDiskOptimization = true
-	optimizeCheckpointConfiguration.WorkingStore = table.Store
+	optimizeCheckpointConfiguration.WorkingStore = store
 	optimizeCheckpointConfiguration.WorkingFolder = storage.NewPath(fmt.Sprintf("_delta_log/.tmp/checkpoint-v%d-%s", version, uuid.NewString()))
 	return optimizeCheckpointConfiguration, nil
 }

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -97,10 +97,9 @@ func copyFilesToTempDirRecursively(t *testing.T, inputFolder string, outputFolde
 }
 
 func TestCheckpointInUseWorkingFolder(t *testing.T) {
-	store, stateStore, lock, checkpointLock := setupCheckpointTest(t, "testdata/checkpoints/simple")
-	table := NewTable(store, lock, stateStore)
+	store, _, _, checkpointLock := setupCheckpointTest(t, "testdata/checkpoints/simple")
 	checkpointConfiguration := NewCheckpointConfiguration()
-	optimizeConfig, err := NewOptimizeCheckpointConfiguration(table, 5)
+	optimizeConfig, err := NewOptimizeCheckpointConfiguration(store, 5)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Changes
We don't need the table, just the store

## Tests


- [X] `make test` passing
- [ ] relevant integration tests passing
