### PR TITLE
refactor!: ensure that transaction options are set to default if not provided

### DIFF
--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -287,7 +287,7 @@ func getTestRemove(offsetMillis int64, path string) *Remove {
 
 func testDoCommit(t *testing.T, table *Table, actions []Action) (int64, error) {
 	t.Helper()
-	tx := table.CreateTransaction(&TransactionOptions{})
+	tx := table.CreateTransaction(NewTransactionOptions())
 	tx.AddActions(actions)
 	return tx.Commit()
 }

--- a/delta.go
+++ b/delta.go
@@ -101,8 +101,33 @@ func NewTableWithLogStore(store storage.ObjectStore, lock lock.Locker, logStore 
 // Creates a new Transaction for the Table.
 // The transaction holds a mutable reference to the Table, preventing other references
 // until the transaction is dropped.
-func (table *Table) CreateTransaction(options *TransactionOptions) *Transaction {
-	return NewTransaction(table, options)
+func (table *Table) CreateTransaction(opts TransactionOptions) *transaction {
+	opts.setOptionsDefaults()
+
+	transaction := new(transaction)
+	transaction.Table = table
+	transaction.options = opts
+
+	return transaction
+}
+
+// setOptionsDefaults sets the default transaction options.
+func (opts *TransactionOptions) setOptionsDefaults() {
+	if opts.MaxRetryCommitAttempts == 0 {
+		opts.MaxRetryCommitAttempts = defaultMaxRetryCommitAttempts
+	}
+	if opts.MaxRetryReadAttempts == 0 {
+		opts.MaxRetryReadAttempts = defaultMaxRetryCommitAttempts
+	}
+	if opts.MaxRetryWriteAttempts == 0 {
+		opts.MaxRetryWriteAttempts = defaultMaxWriteCommitAttempts
+	}
+	if opts.RetryCommitAttemptsBeforeLoadingTable == 0 {
+		opts.RetryCommitAttemptsBeforeLoadingTable = defaultRetryCommitAttemptsBeforeLoadingTable
+	}
+	if opts.MaxRetryLogFixAttempts == 0 {
+		opts.MaxRetryLogFixAttempts = defaultMaxRetryLogFixAttempts
+	}
 }
 
 // / Return the uri of commit version.
@@ -806,12 +831,12 @@ func (dtmd *TableMetaData) GetPartitionColDataTypes() map[string]SchemaDataType 
 // /
 // / Please not that in case of non-retryable error the temporary commit file such as
 // / `_delta_log/_commit_<uuid>.json` will orphaned in storage.
-type Transaction struct {
+type transaction struct {
 	Table       *Table
 	Actions     []Action
 	Operation   Operation
 	AppMetadata map[string]any
-	Options     *TransactionOptions
+	options     TransactionOptions
 }
 
 // ReadActions gets actions from a file.
@@ -821,11 +846,11 @@ type Transaction struct {
 // target N.json file more than once. Though data loss will *NOT* occur, readers of N.json
 // may receive an error from S3 as the ETag of N.json was changed. This is safe to
 // retry, so we do so here.
-func (transaction *Transaction) ReadActions(path storage.Path) ([]Action, error) {
+func (transaction *transaction) ReadActions(path storage.Path) ([]Action, error) {
 	attempt := 0
 	for {
-		if attempt >= int(transaction.Options.MaxRetryReadAttempts) {
-			return nil, fmt.Errorf("failed to get actions after %d attempts", transaction.Options.MaxRetryReadAttempts)
+		if attempt >= int(transaction.options.MaxRetryReadAttempts) {
+			return nil, fmt.Errorf("failed to get actions after %d attempts", transaction.options.MaxRetryReadAttempts)
 		}
 
 		entry, err := transaction.Table.Store.Get(path)
@@ -863,11 +888,11 @@ func (transaction *Transaction) ReadActions(path storage.Path) ([]Action, error)
 //
 // - Step 4: ACKNOWLEDGE the commit.
 //   - Overwrite and complete commit entry E in the log store.
-func (transaction *Transaction) CommitLogStore() (int64, error) {
+func (transaction *transaction) CommitLogStore() (int64, error) {
 	attempt := 0
 	for {
-		if attempt >= int(transaction.Options.MaxRetryWriteAttempts) {
-			return -1, fmt.Errorf("failed to commit with log store after %d attempts", transaction.Options.MaxRetryWriteAttempts)
+		if attempt >= int(transaction.options.MaxRetryWriteAttempts) {
+			return -1, fmt.Errorf("failed to commit with log store after %d attempts", transaction.options.MaxRetryWriteAttempts)
 		}
 
 		version, err := transaction.tryCommitLogStore()
@@ -881,7 +906,7 @@ func (transaction *Transaction) CommitLogStore() (int64, error) {
 	}
 }
 
-func (t *Transaction) tryCommitLogStore() (version int64, err error) {
+func (t *transaction) tryCommitLogStore() (version int64, err error) {
 	var currURI storage.Path
 	prevURI, err := t.Table.LogStore.Latest(t.Table.Store.BaseURI())
 
@@ -1014,7 +1039,7 @@ func (t *Transaction) tryCommitLogStore() (version int64, err error) {
 	return currVersion, nil
 }
 
-func (t *Transaction) complete(entry *logstore.CommitEntry) error {
+func (t *transaction) complete(entry *logstore.CommitEntry) error {
 	seconds := t.Table.LogStore.ExpirationDelaySeconds()
 	entry, err := entry.Complete(seconds)
 	if err != nil {
@@ -1028,15 +1053,15 @@ func (t *Transaction) complete(entry *logstore.CommitEntry) error {
 	return nil
 }
 
-func (t *Transaction) copyTempFile(src storage.Path, dst storage.Path) error {
+func (t *transaction) copyTempFile(src storage.Path, dst storage.Path) error {
 	return t.Table.Store.RenameIfNotExists(src, dst)
 }
 
-func (t *Transaction) createTempPath(path storage.Path) (storage.Path, error) {
+func (t *transaction) createTempPath(path storage.Path) (storage.Path, error) {
 	return storage.NewPath(fmt.Sprintf(".tmp/%s.%s", path.Raw, uuid.New().String())), nil
 }
 
-func (t *Transaction) fixLog(entry *logstore.CommitEntry) (err error) {
+func (t *transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 	if entry.IsComplete() {
 		return nil
 	}
@@ -1062,8 +1087,8 @@ func (t *Transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 
 	attempt, copied := 0, false
 	for {
-		if attempt >= int(t.Options.MaxRetryLogFixAttempts) {
-			return fmt.Errorf("failed to fix Delta log after %d attempts", t.Options.MaxRetryLogFixAttempts)
+		if attempt >= int(t.options.MaxRetryLogFixAttempts) {
+			return fmt.Errorf("failed to fix Delta log after %d attempts", t.options.MaxRetryLogFixAttempts)
 		}
 
 		log.Infof("delta-go: Trying to fix %s.", entry.FileName().Raw)
@@ -1099,7 +1124,7 @@ func (t *Transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 	}
 }
 
-func (transaction *Transaction) writeActions(path storage.Path, actions []Action) error {
+func (transaction *transaction) writeActions(path storage.Path, actions []Action) error {
 	// Serialize all actions that are part of this log entry.
 	entry, err := LogEntryFromActions(actions)
 	if err != nil {
@@ -1109,28 +1134,18 @@ func (transaction *Transaction) writeActions(path storage.Path, actions []Action
 	return transaction.Table.Store.Put(path, entry)
 }
 
-// / Creates a new Delta transaction.
-// / Holds a mutable reference to the Delta table to prevent outside mutation while a transaction commit is in progress.
-// / Transaction behavior may be customized by passing an instance of `TransactionOptions`.
-func NewTransaction(table *Table, options *TransactionOptions) *Transaction {
-	transaction := new(Transaction)
-	transaction.Table = table
-	transaction.Options = options
-	return transaction
-}
-
 // / Add an arbitrary "action" to the actions associated with this transaction
-func (transaction *Transaction) AddAction(action Action) {
+func (transaction *transaction) AddAction(action Action) {
 	transaction.Actions = append(transaction.Actions, action)
 }
 
 // / Add an arbitrary number of actions to the actions associated with this transaction
-func (transaction *Transaction) AddActions(actions []Action) {
+func (transaction *transaction) AddActions(actions []Action) {
 	transaction.Actions = append(transaction.Actions, actions...)
 }
 
 // AddCommitInfo adds a `commitInfo` action to a transaction's actions if not already present.
-func (t *Transaction) AddCommitInfoIfNotPresent() {
+func (t *transaction) AddCommitInfoIfNotPresent() {
 	found := false
 	for _, action := range t.Actions {
 		switch action.(type) {
@@ -1156,18 +1171,18 @@ func (t *Transaction) AddCommitInfoIfNotPresent() {
 }
 
 // SetOperation sets the Delta operation for this transaction.
-func (transaction *Transaction) SetOperation(operation Operation) {
+func (transaction *transaction) SetOperation(operation Operation) {
 	transaction.Operation = operation
 }
 
 // SetAppMetadata sets the app metadata for this transaction.
-func (transaction *Transaction) SetAppMetadata(appMetadata map[string]any) {
+func (transaction *transaction) SetAppMetadata(appMetadata map[string]any) {
 	transaction.AppMetadata = appMetadata
 }
 
 // Commits the given actions to the Delta log.
 // This method will retry the transaction commit based on the value of `max_retry_commit_attempts` set in `TransactionOptions`.
-func (transaction *Transaction) Commit() (int64, error) {
+func (transaction *transaction) Commit() (int64, error) {
 	PreparedCommit, err := transaction.PrepareCommit()
 	if err != nil {
 		log.Debugf("delta-go: PrepareCommit attempt failed. %v", err)
@@ -1181,7 +1196,7 @@ func (transaction *Transaction) Commit() (int64, error) {
 // / Low-level transaction API. Creates a temporary commit file. Once created,
 // / the transaction object could be dropped and the actual commit could be executed
 // / with `Table.try_commit_transaction`.
-func (transaction *Transaction) PrepareCommit() (PreparedCommit, error) {
+func (transaction *transaction) PrepareCommit() (PreparedCommit, error) {
 	transaction.AddCommitInfoIfNotPresent()
 
 	// Serialize all actions that are part of this log entry.
@@ -1207,14 +1222,14 @@ func (transaction *Transaction) PrepareCommit() (PreparedCommit, error) {
 }
 
 // TryCommitLoop loads metadata from lock containing the latest locked version and tries to obtain the lock and commit for the version + 1 in a loop
-func (transaction *Transaction) TryCommitLoop(commit *PreparedCommit) error {
+func (transaction *transaction) TryCommitLoop(commit *PreparedCommit) error {
 	attemptNumber := 0
 	for {
 		if attemptNumber > 0 {
-			time.Sleep(transaction.Options.RetryWaitDuration)
+			time.Sleep(transaction.options.RetryWaitDuration)
 		}
-		if attemptNumber > int(transaction.Options.MaxRetryCommitAttempts)+1 {
-			log.Debugf("delta-go: Transaction attempt failed. Attempts exhausted beyond max_retry_commit_attempts of %d so failing.", transaction.Options.MaxRetryCommitAttempts)
+		if attemptNumber > int(transaction.options.MaxRetryCommitAttempts)+1 {
+			log.Debugf("delta-go: Transaction attempt failed. Attempts exhausted beyond max_retry_commit_attempts of %d so failing.", transaction.options.MaxRetryCommitAttempts)
 			return ErrExceededCommitRetryAttempts
 		}
 
@@ -1222,12 +1237,12 @@ func (transaction *Transaction) TryCommitLoop(commit *PreparedCommit) error {
 		//Reset local state with the version tried in the commit
 		//The next attempt should use the max of the remote state and local state, enables local incrimination if the remote state is stuck
 		if errors.Is(err, storage.ErrObjectAlreadyExists) || errors.Is(err, lock.ErrLockNotObtained) { //|| errors.Is(err, state.ErrorStateIsEmpty) || errors.Is(err, state.ErrorCanNotReadState) || errors.Is(err, state.ErrorCanNotWriteState) {
-			if attemptNumber <= int(transaction.Options.MaxRetryCommitAttempts)+1 {
+			if attemptNumber <= int(transaction.options.MaxRetryCommitAttempts)+1 {
 				attemptNumber += 1
 				log.Debugf("delta-go: Transaction attempt failed with '%v'. Incrementing attempt number to %d and retrying.", err, attemptNumber)
 				// TODO: check if state is higher then current latest version of table by checking n-1
-				if transaction.Options.RetryCommitAttemptsBeforeLoadingTable > 0 &&
-					attemptNumber%int(transaction.Options.RetryCommitAttemptsBeforeLoadingTable) == 0 {
+				if transaction.options.RetryCommitAttemptsBeforeLoadingTable > 0 &&
+					attemptNumber%int(transaction.options.RetryCommitAttemptsBeforeLoadingTable) == 0 {
 					// Every 100 attempts, sync the table's state store with its latest version.
 					err := transaction.Table.SyncStateStore()
 					if err != nil {
@@ -1235,7 +1250,7 @@ func (transaction *Transaction) TryCommitLoop(commit *PreparedCommit) error {
 					}
 				}
 			} else {
-				log.Debugf("delta-go: Transaction attempt failed. Attempts exhausted beyond max_retry_commit_attempts of %d so failing.", transaction.Options.MaxRetryCommitAttempts)
+				log.Debugf("delta-go: Transaction attempt failed. Attempts exhausted beyond max_retry_commit_attempts of %d so failing.", transaction.options.MaxRetryCommitAttempts)
 				return err
 			}
 		} else {
@@ -1247,7 +1262,7 @@ func (transaction *Transaction) TryCommitLoop(commit *PreparedCommit) error {
 }
 
 // TryCommitLoop: Loads metadata from lock containing the latest locked version and tries to obtain the lock and commit for the version + 1 in a loop
-func (transaction *Transaction) TryCommit(commit *PreparedCommit) (err error) {
+func (transaction *transaction) TryCommit(commit *PreparedCommit) (err error) {
 	// Step 1) Acquire Lock
 	locked, err := transaction.Table.LockClient.TryLock()
 	// Step 5) Always Release Lock
@@ -1342,8 +1357,8 @@ type TransactionOptions struct {
 }
 
 // NewTransactionOptions sets the default transaction options.
-func NewTransactionOptions() *TransactionOptions {
-	return &TransactionOptions{MaxRetryCommitAttempts: defaultMaxRetryCommitAttempts, MaxRetryWriteAttempts: defaultMaxWriteCommitAttempts, MaxRetryLogFixAttempts: defaultMaxRetryLogFixAttempts, RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable}
+func NewTransactionOptions() TransactionOptions {
+	return TransactionOptions{MaxRetryCommitAttempts: defaultMaxRetryCommitAttempts, MaxRetryWriteAttempts: defaultMaxWriteCommitAttempts, MaxRetryLogFixAttempts: defaultMaxRetryLogFixAttempts, RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable}
 }
 
 // OpenTableWithVersion loads the table at this specific version

--- a/delta_test.go
+++ b/delta_test.go
@@ -56,7 +56,7 @@ func TestDeltaTransactionPrepareCommit(t *testing.T) {
 	options := TransactionOptions{MaxRetryCommitAttempts: 3}
 	os.MkdirAll("tmp/_delta_log/", 0700)
 	defer os.RemoveAll("tmp/_delta_log/")
-	transaction := NewTransaction(&deltaTable, &options)
+	transaction := deltaTable.CreateTransaction(options)
 	add := Add{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
 		Size:             984,
@@ -96,7 +96,7 @@ func TestDeltaTransactionPrepareCommit(t *testing.T) {
 func TestDeltaTableReadCommitVersion(t *testing.T) {
 	table, _, _ := setupTest(t)
 	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -160,7 +160,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 		t.Error(err)
 	}
 
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -214,7 +214,7 @@ func TestDeltaTableReadCommitVersionWithAddStats(t *testing.T) {
 func TestDeltaTableTryCommitTransaction(t *testing.T) {
 	table, _, _ := setupTest(t)
 	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -266,7 +266,7 @@ func TestTryCommitWithExistingLock(t *testing.T) {
 
 	table := NewTable(store, lockClient, state)
 
-	transaction := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 3})
+	transaction := setupTransaction(t, table, TransactionOptions{MaxRetryCommitAttempts: 3})
 
 	version, err := transaction.Commit()
 	if !errors.Is(err, ErrExceededCommitRetryAttempts) {
@@ -321,7 +321,7 @@ func TestCommitUnlockFailure(t *testing.T) {
 
 	table := NewTable(store, &lockClient, state)
 
-	transaction := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 3})
+	transaction := setupTransaction(t, table, TransactionOptions{MaxRetryCommitAttempts: 3})
 	_, err := transaction.Commit()
 	if !errors.Is(err, lock.ErrUnableToUnlock) {
 		t.Error(err)
@@ -338,7 +338,7 @@ func TestTryCommitWithNilLockAndLocalState(t *testing.T) {
 	table := NewTable(store, lock, storeState)
 
 	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -438,7 +438,7 @@ func TestDeltaTableExists(t *testing.T) {
 	}
 
 	// Create another version file
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -528,7 +528,7 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 		t.Error(err)
 	}
 	// Create another version file
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -571,7 +571,7 @@ func TestDeltaTableExistsManyTempFiles(t *testing.T) {
 func TestDeltaTableTryCommitLoop(t *testing.T) {
 	table, _, _ := setupTest(t)
 
-	transaction := setupTransaction(t, table, &TransactionOptions{})
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -597,7 +597,7 @@ func TestDeltaTableTryCommitLoop(t *testing.T) {
 func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
 	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction := setupTransaction(t, table, &TransactionOptions{MaxRetryCommitAttempts: 5, RetryWaitDuration: time.Second})
+	transaction := setupTransaction(t, table, TransactionOptions{MaxRetryCommitAttempts: 5, RetryWaitDuration: time.Second})
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -647,7 +647,7 @@ func TestDeltaTableTryCommitLoopWithCommitExists(t *testing.T) {
 func TestDeltaTableTryCommitLoopStateStoreOutOfSync(t *testing.T) {
 	table, _, tmpDir := setupTest(t)
 	table.Create(TableMetaData{}, Protocol{}, CommitInfo{}, []Add{})
-	transaction := setupTransaction(t, table, &TransactionOptions{
+	transaction := setupTransaction(t, table, TransactionOptions{
 		MaxRetryCommitAttempts:                5, //Should break on max attempts if the latest version logic fails
 		RetryWaitDuration:                     time.Second,
 		RetryCommitAttemptsBeforeLoadingTable: 2, //Should get the latest version after 2 attempts
@@ -1056,10 +1056,10 @@ func setupTest(t *testing.T) (table *Table, state *filestate.FileStateStore, tmp
 }
 
 // / Helper function to set up a basic transaction
-func setupTransaction(t *testing.T, table *Table, options *TransactionOptions) (transaction *Transaction) {
+func setupTransaction(t *testing.T, table *Table, opts TransactionOptions) (transaction *transaction) {
 	t.Helper()
 
-	transaction = table.CreateTransaction(options)
+	transaction = table.CreateTransaction(opts)
 	add := Add{
 		Path:             "part-00000-80a9bb40-ec43-43b6-bb8a-fc66ef7cd768-c000.snappy.parquet",
 		Size:             984,
@@ -1242,7 +1242,7 @@ func TestLatestVersion(t *testing.T) {
 		t.Errorf("After adding first commit: LatestVersion() = %v, want %v", version, 0)
 	}
 
-	transaction := setupTransaction(t, table, nil)
+	transaction := setupTransaction(t, table, NewTransactionOptions())
 
 	commit, err := transaction.PrepareCommit()
 	if err != nil {
@@ -1480,7 +1480,7 @@ func TestLoadVersion(t *testing.T) {
 }
 
 // Performs common setup for the log store tests, creating a Delta table backed by mock DynamoDB and S3 clients
-func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, table *Table, transaction *Transaction) {
+func setUpSingleClusterLogStoreTest(t *testing.T) (logStoreTableName string, table *Table, transaction *transaction) {
 	t.Helper()
 
 	logStoreTableName = "version_log_store"
@@ -2005,8 +2005,8 @@ func TestCommitLogStore_DifferentClients(t *testing.T) {
 	var (
 		wg                sync.WaitGroup
 		transactions      = 100
-		firstTransaction  *Transaction
-		secondTransaction *Transaction
+		firstTransaction  *transaction
+		secondTransaction *transaction
 	)
 	for i := 1; i < transactions/2+1; i++ {
 		wg.Add(1)
@@ -2292,8 +2292,8 @@ func TestCommitLogStore_EmptyLogStoreTableExists(t *testing.T) {
 	var (
 		wg                sync.WaitGroup
 		transactions      = 100
-		firstTransaction  *Transaction
-		secondTransaction *Transaction
+		firstTransaction  *transaction
+		secondTransaction *transaction
 	)
 	for i := 1; i < transactions/2+1; i++ {
 		wg.Add(1)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Ensures that transaction options are set to their default values if not provided by the user.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] relevant integration tests passing
