### PR TITLE
Release previous record when getting new record via SetColumn

### DIFF
--- a/ondiskstate.go
+++ b/ondiskstate.go
@@ -435,6 +435,8 @@ func newRecordForAddsAndRemoves(newAdds map[string]Add, newRemoves map[string]Re
 		if err != nil {
 			return nil, err
 		}
+		// SetColumn returns a new record
+		defer newRecord.Release()
 		newRecord, err = newRecord.SetColumn(addFieldIndex, newAddsArray)
 		if err != nil {
 			return nil, err
@@ -452,6 +454,8 @@ func newRecordForAddsAndRemoves(newAdds map[string]Add, newRemoves map[string]Re
 		if err != nil {
 			return nil, err
 		}
+		// SetColumn returns a new record
+		defer newRecord.Release()
 		newRecord, err = newRecord.SetColumn(removeFieldIndex, newRemovesArray)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Changes
The `record.SetColumn()` function actually returns a new record, so the previous record needs a `Release()` call.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [X] `make test` passing
- [ ] relevant integration tests passing
