### PR TITLE
fix: sleep between log store commit retries

### DIFF
--- a/delta.go
+++ b/delta.go
@@ -1306,11 +1306,12 @@ type PreparedCommit struct {
 }
 
 const (
-	defaultMaxRetryCommitAttempts                uint32 = 10000000
-	defaultMaxReadAttempts                       uint16 = 3
-	defaultMaxWriteAttempts                      uint32 = 10000000
-	defaultRetryCommitAttemptsBeforeLoadingTable uint32 = 100
-	defaultMaxRetryLogFixAttempts                uint16 = 3
+	defaultMaxRetryCommitAttempts                uint32        = 10000000
+	defaultRetryWaitDuration                     time.Duration = 500 * time.Millisecond
+	defaultMaxReadAttempts                       uint16        = 3
+	defaultMaxWriteAttempts                      uint32        = 10000000
+	defaultRetryCommitAttemptsBeforeLoadingTable uint32        = 100
+	defaultMaxRetryLogFixAttempts                uint16        = 3
 )
 
 // Options for customizing behavior of a `Transaction`
@@ -1332,7 +1333,12 @@ type TransactionOptions struct {
 
 // NewTransactionOptions sets the default transaction options.
 func NewTransactionOptions() TransactionOptions {
-	return TransactionOptions{MaxRetryCommitAttempts: defaultMaxRetryCommitAttempts, MaxRetryWriteAttempts: defaultMaxWriteAttempts, MaxRetryLogFixAttempts: defaultMaxRetryLogFixAttempts, RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable}
+	return TransactionOptions{MaxRetryCommitAttempts: defaultMaxRetryCommitAttempts,
+		RetryWaitDuration:                     defaultRetryWaitDuration,
+		MaxRetryReadAttempts:                  defaultMaxReadAttempts,
+		MaxRetryWriteAttempts:                 defaultMaxWriteAttempts,
+		RetryCommitAttemptsBeforeLoadingTable: defaultRetryCommitAttemptsBeforeLoadingTable,
+		MaxRetryLogFixAttempts:                defaultMaxRetryLogFixAttempts}
 }
 
 // OpenTableWithVersion loads the table at this specific version

--- a/delta.go
+++ b/delta.go
@@ -883,6 +883,9 @@ func (t *transaction) CommitLogStore() (int64, error) {
 		if err != nil {
 			attempt++
 			log.Debugf("delta-go: Attempt number %d: failed to commit with log store. %v", attempt, err)
+
+			time.Sleep(t.options.RetryWaitDuration)
+
 			continue
 		}
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Adds a sleep between log store commit retries. Most of the errors in `tryCommitLogStore()` come from other writers committing concurrently. Adding a sleep will reduce writer contention.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
