### PR TITLE
refactor: error out if a temp file copy fails

### DIFF
--- a/delta.go
+++ b/delta.go
@@ -911,7 +911,7 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 				return -1, fmt.Errorf("put first commit entry: %v", err)
 			}
 			log.WithFields(log.Fields{"tablePath": t.Table.Store.BaseURI().Raw, "fileName": fileName.Raw}).
-				Infof("delta-go: Put completed commit entry in empty log store.")
+				Infof("delta-go: Put completed commit entry in empty log store")
 
 			currURI = CommitURIFromVersion(version + 1)
 		} else if errors.Is(err, ErrNotATable) {
@@ -1067,7 +1067,7 @@ func (t *transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 			return fmt.Errorf("failed to fix Delta log after %d attempts: %v", t.options.MaxRetryLogFixAttempts, err)
 		}
 
-		log.Infof("delta-go: Trying to fix %s.", entry.FileName().Raw)
+		log.WithField("tablePath", entry.TablePath().Raw).Infof("delta-go: Trying to fix %s", entry.FileName().Raw)
 
 		if _, err = t.Table.Store.Head(filePath); !copied && err != nil {
 			tempPath, err := entry.AbsoluteTempPath()
@@ -1094,7 +1094,7 @@ func (t *transaction) fixLog(entry *logstore.CommitEntry) (err error) {
 			continue
 		}
 
-		log.Infof("delta-go: Fixed file %s.", entry.FileName().Raw)
+		log.WithField("tablePath", entry.TablePath().Raw).Infof("delta-go: Fixed file %s", entry.FileName().Raw)
 		return nil
 	}
 }

--- a/delta.go
+++ b/delta.go
@@ -48,6 +48,7 @@ var (
 	ErrNotImplemented              error = errors.New("not implemented")
 	ErrUnsupportedReaderVersion    error = errors.New("reader version is unsupported")
 	ErrUnsupportedWriterVersion    error = errors.New("writer version is unsupported")
+	ErrFailedToCopyTempFile        error = errors.New("failed to copy temp file")
 	ErrFailedToAcknowledgeCommit   error = errors.New("failed to acknowledge commit")
 )
 
@@ -879,7 +880,7 @@ func (t *transaction) CommitLogStore() (int64, error) {
 		}
 
 		version, err = t.tryCommitLogStore()
-		if errors.Is(err, ErrFailedToAcknowledgeCommit) {
+		if errors.Is(err, ErrFailedToCopyTempFile) || errors.Is(err, ErrFailedToAcknowledgeCommit) {
 			return version, err
 		} else if err != nil {
 			attempt++
@@ -903,23 +904,20 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 			fileName := storage.NewPath(strings.Split(uri, "_delta_log/")[1])
 			seconds := t.Table.LogStore.ExpirationDelaySeconds()
 
-			entry, err := logstore.New(t.Table.Store.BaseURI(), fileName,
+			entry := logstore.New(t.Table.Store.BaseURI(), fileName,
 				storage.NewPath("") /* tempPath */, true /* isComplete */, uint64(time.Now().Unix())+seconds)
-			if err != nil {
-				return -1, fmt.Errorf("create first commit entry: %v", err)
-			}
 
 			if err := t.Table.LogStore.Put(entry, false); err != nil {
 				return -1, fmt.Errorf("put first commit entry: %v", err)
 			}
-			log.Debugf("delta-go: Put completed commit entry for table path %s and file name %s in the empty log store.",
-				t.Table.Store.BaseURI(), fileName)
+			log.WithFields(log.Fields{"tablePath": t.Table.Store.BaseURI().Raw, "fileName": fileName.Raw}).
+				Infof("delta-go: Put completed commit entry in empty log store.")
 
 			currURI = CommitURIFromVersion(version + 1)
-		} else if err != nil && !errors.Is(err, ErrNotATable) {
-			return -1, errors.Join(errors.New("failed to determine if table exists"), err)
-		} else {
+		} else if errors.Is(err, ErrNotATable) {
 			currURI = CommitURIFromVersion(0)
+		} else {
+			return -1, errors.Join(fmt.Errorf("failed to determine if table %s exists", t.Table.Store.BaseURI().Raw), err)
 		}
 	} else if err != nil {
 		return -1, errors.Join(errors.New("failed to get latest log store entry"), err)
@@ -979,7 +977,7 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 	} else {
 		if entry, err := t.Table.LogStore.Get(t.Table.Store.BaseURI(), fileName); err == nil {
 			if _, err := t.Table.Store.Head(currURI); entry.IsComplete() && err != nil {
-				return -1, fmt.Errorf("old entries for table %s still in log store", t.Table.Store.BaseURI())
+				return -1, fmt.Errorf("old entries for table %s still in log store", t.Table.Store.BaseURI().Raw)
 			}
 		}
 	}
@@ -991,10 +989,7 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 	}
 	relativeTempPath := storage.NewPath("_delta_log").Join(tempPath)
 
-	entry, err := logstore.New(t.Table.Store.BaseURI(), fileName, tempPath, false /* isComplete */, 0 /* expirationTime */)
-	if err != nil {
-		return -1, fmt.Errorf("create commit entry: %v", err)
-	}
+	entry := logstore.New(t.Table.Store.BaseURI(), fileName, tempPath, false /* isComplete */, 0 /* expirationTime */)
 
 	if err := t.writeActions(relativeTempPath, t.Actions); err != nil {
 		return -1, fmt.Errorf("write actions: %v", err)
@@ -1008,7 +1003,8 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 	// Step 3: COMMIT the commit to the Delta log.
 	//         Copy T(N) -> N.json.
 	if err := t.copyTempFile(relativeTempPath, currURI); err != nil {
-		return -1, fmt.Errorf("copy temp file to N.json: %v", err)
+		return -1, errors.Join(ErrFailedToCopyTempFile,
+			fmt.Errorf("copy temp file %s to %s: %v", relativeTempPath.Raw, currURI.Raw, err))
 	}
 
 	// Step 4: ACKNOWLEDGE the commit.
@@ -1021,10 +1017,7 @@ func (t *transaction) tryCommitLogStore() (version int64, err error) {
 
 func (t *transaction) complete(entry *logstore.CommitEntry) error {
 	seconds := t.Table.LogStore.ExpirationDelaySeconds()
-	entry, err := entry.Complete(seconds)
-	if err != nil {
-		return fmt.Errorf("complete commit entry: %v", err)
-	}
+	entry = entry.Complete(seconds)
 
 	if err := t.Table.LogStore.Put(entry, true); err != nil {
 		return fmt.Errorf("put completed commit entry: %v", err)

--- a/logstore/commitentry.go
+++ b/logstore/commitentry.go
@@ -33,7 +33,7 @@ type CommitEntry struct {
 }
 
 // New creates a new CommitEntry instance.
-func New(tablePath storage.Path, fileName storage.Path, tempPath storage.Path, isComplete bool, expirationTime uint64) (*CommitEntry, error) {
+func New(tablePath storage.Path, fileName storage.Path, tempPath storage.Path, isComplete bool, expirationTime uint64) *CommitEntry {
 	ce := new(CommitEntry)
 	ce.tablePath = tablePath
 	ce.fileName = fileName
@@ -41,7 +41,7 @@ func New(tablePath storage.Path, fileName storage.Path, tempPath storage.Path, i
 	ce.isComplete = isComplete
 	ce.expirationTime = expirationTime
 
-	return ce, nil
+	return ce
 }
 
 // TablePath gets the table path for a commit entry.
@@ -70,7 +70,7 @@ func (ce *CommitEntry) ExpirationTime() uint64 {
 }
 
 // Complete completes a commit entry.
-func (ce *CommitEntry) Complete(expirationDelaySeconds uint64) (*CommitEntry, error) {
+func (ce *CommitEntry) Complete(expirationDelaySeconds uint64) *CommitEntry {
 	return New(ce.tablePath, ce.fileName, ce.tempPath, true, uint64(time.Now().Unix())+expirationDelaySeconds)
 }
 

--- a/logstore/dynamodblogstore/dynamodblogstore.go
+++ b/logstore/dynamodblogstore/dynamodblogstore.go
@@ -271,7 +271,7 @@ func (ls *LogStore) mapItemToEntry(item map[string]types.AttributeValue) (*logst
 		storage.NewPath(item[string(TempPath)].(*types.AttributeValueMemberS).Value),
 		item[string(Complete)].(*types.AttributeValueMemberS).Value == "true",
 		time,
-	)
+	), nil
 }
 
 // createPutItemRequest creates a put item request.

--- a/logstore/dynamodblogstore/dynamodblogstore.go
+++ b/logstore/dynamodblogstore/dynamodblogstore.go
@@ -191,14 +191,15 @@ func New(o Options) (*LogStore, error) {
 		},
 		TableName: aws.String(ls.tableName),
 	}
-	dynamodbutils.CreateTableIfNotExists(ls.client, ls.tableName, cti, ls.maxTableCreateAttempts)
+	err := dynamodbutils.CreateTableIfNotExists(ls.client, ls.tableName, cti, ls.maxTableCreateAttempts)
 
-	return ls, nil
+	return ls, err
 }
 
 // Put puts a commit entry into a log store in an exclusive way.
 func (ls *LogStore) Put(entry *logstore.CommitEntry, overwrite bool) error {
-	log.Debugf("delta-go: PutItem (tablePath %s, fileName %s, tempPath %s, complete %t, expireTime %d, overwrite %t)", entry.TablePath(), entry.FileName(), entry.TempPath(), entry.IsComplete(), entry.ExpirationTime(), overwrite)
+	log.Debugf("delta-go: PutItem (tablePath %s, fileName %s, tempPath %s, complete %t, expireTime %d, overwrite %t)",
+		entry.TablePath(), entry.FileName(), entry.TempPath(), entry.IsComplete(), entry.ExpirationTime(), overwrite)
 
 	pir, err := ls.createPutItemRequest(entry, overwrite)
 	if err != nil {

--- a/logstore/dynamodblogstore/dynamodblogstore_test.go
+++ b/logstore/dynamodblogstore/dynamodblogstore_test.go
@@ -27,7 +27,7 @@ func TestPut(t *testing.T) {
 		t.Error("Failed to create DynamoDB log store")
 	}
 
-	ce, err := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
+	ce := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}
@@ -35,7 +35,7 @@ func TestPut(t *testing.T) {
 		t.Error("Failed to put commit entry")
 	}
 
-	ce, err = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), true, uint64(0))
+	ce = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), true, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}
@@ -67,7 +67,7 @@ func TestGet(t *testing.T) {
 		t.Error("Failed to create new DynamoDB log store")
 	}
 
-	ce, err := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
+	ce := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}
@@ -75,7 +75,7 @@ func TestGet(t *testing.T) {
 		t.Error("Failed to put commit entry")
 	}
 
-	ce, err = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
+	ce = logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}
@@ -106,7 +106,7 @@ func TestLatest(t *testing.T) {
 		t.Error("Failed to create DynamoDB log store")
 	}
 
-	firstEntry, err := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
+	firstEntry := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("01.json"), storage.NewPath("01.tmp"), false, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}
@@ -114,7 +114,7 @@ func TestLatest(t *testing.T) {
 		t.Error("Failed to put commit entry")
 	}
 
-	secondEntry, err := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("02.json"), storage.NewPath("02.tmp"), false, uint64(0))
+	secondEntry := logstore.New(storage.NewPath("usr/local/"), storage.NewPath("02.json"), storage.NewPath("02.tmp"), false, uint64(0))
 	if err != nil {
 		t.Error("Failed to create commit entry")
 	}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
- Errors out of `CommitLogStore()` if copying a temp file into a commit URI fails. Any operation performed after an uncompleted commit entry has been put in a log store shouldn't be retried; other writers can complete the commit entry.
- Improves descriptiveness of some info logs.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
