### PR TITLE
Fix checkpoint parts count logic

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -190,7 +190,7 @@ func DoesCheckpointVersionExist(store storage.ObjectStore, version int64, valida
 	// List all files starting with the version prefix.  This will also find commit logs and possible crc files
 	str := fmt.Sprintf("%020d", version)
 	path := storage.PathFromIter([]string{"_delta_log", str})
-	possibleCheckpointFiles, err := store.List(path, nil)
+	possibleCheckpointFiles, err := store.ListAll(path)
 	if err != nil {
 		return false, err
 	}

--- a/delta.go
+++ b/delta.go
@@ -550,7 +550,7 @@ func (t *Table) findLatestCheckpointsForVersion(version *int64) (checkpoints []C
 			isCompleteCheckpoint := true
 			if checkpoint.Parts != nil {
 				isCompleteCheckpoint, err = DoesCheckpointVersionExist(t.Store, checkpoint.Version, true)
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrCheckpointIncomplete) && !errors.Is(err, ErrCheckpointInvalidMultipartFileName) {
 					return nil, false, err
 				}
 			}


### PR DESCRIPTION
## Changes

Fix for an issue that shows up in very specific circumstances: if there's an issue with the `_last_checkpoint` file and also the checkpoint has more than 1000 parts.

First, changed the `List` call to`ListAll` to get all checkpoint parts.
Second, if the check in `findLatestCheckpointsForVersion` for whether it's a complete checkpoint fails because there are parts missing or because there are filename issues, don't fail out - keep looking for another valid checkpoint instead.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [ ] `make test` passing
- [ ] relevant integration tests passing
