### PR TITLE
fix: improve error handling when copying a temporary file

### DIFF
--- a/logstore/commitentry.go
+++ b/logstore/commitentry.go
@@ -76,12 +76,22 @@ func (ce *CommitEntry) Complete(expirationDelaySeconds uint64) *CommitEntry {
 	return New(ce.tablePath, ce.fileName, ce.tempPath, true, uint64(time.Now().Unix())+expirationDelaySeconds)
 }
 
+// RelativeFilePath gets the file path for a commit entry, relative to the table path.
+func (ce *CommitEntry) RelativeFilePath() storage.Path {
+	return storage.PathFromIter([]string{"_delta_log", ce.fileName.Raw})
+}
+
+// RelativeTempPath gets the temp path for a commit entry, relative to the table path.
+func (ce *CommitEntry) RelativeTempPath() storage.Path {
+	return storage.PathFromIter([]string{"_delta_log", ce.tempPath.Raw})
+}
+
 // AbsoluteFilePath gets the absolute file path for a commit entry.
-func (ce *CommitEntry) AbsoluteFilePath() (storage.Path, error) {
-	return storage.PathFromIter([]string{ce.tablePath.Raw, "_delta_log", ce.fileName.Raw}), nil
+func (ce *CommitEntry) AbsoluteFilePath() storage.Path {
+	return storage.PathFromIter([]string{ce.tablePath.Raw, "_delta_log", ce.fileName.Raw})
 }
 
 // AbsoluteTempPath gets the absolute temp path for a commit entry.
-func (ce *CommitEntry) AbsoluteTempPath() (storage.Path, error) {
-	return storage.PathFromIter([]string{ce.tablePath.Raw, "_delta_log", ce.tempPath.Raw}), nil
+func (ce *CommitEntry) AbsoluteTempPath() storage.Path {
+	return storage.PathFromIter([]string{ce.tablePath.Raw, "_delta_log", ce.tempPath.Raw})
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
In `fixLog()`, if a temporary file's path is unable to be renamed to a commit URI, it can't be assumed that the failure was because the commit URI already exists; it's also possible that the renaming itself failed. I've improved the error handling so that `copyTempFile()` will be retried until either the commit URI exists or the maximum number of log fix attempts have been exhausted.

`Head()` and `copyTempFile()` in `fixLog()` are incorrectly taking absolute file paths as inputs -- I've modified their inputs so they receive relative paths instead. I've added `RelativeFilePath()` and `RelativeTempPath()` as methods of the `CommitEntry` struct to make fetching relative paths easier.

I've grouped some variable declarations to improve readability.

## Tests
<!-- 
How is this tested? Please see the checklist below and also describe any other relevant tests 
-->

- [x] `make test` passing
- [ ] relevant integration tests passing
